### PR TITLE
Add case insensitive order by for list views

### DIFF
--- a/resources/assets/js/app.vue
+++ b/resources/assets/js/app.vue
@@ -28,7 +28,6 @@
     import settingStore from './stores/setting';
     import preferenceStore from './stores/preference';
     import playback from './services/playback';
-    import utils from './services/utils';
 
     export default {
         components: { siteHeader, siteFooter, mainWrapper, overlay },
@@ -195,8 +194,8 @@
         var order = (reverse && reverse < 0) ? -1 : 1
         // sort on a copy to avoid mutating original array
         return arr.slice().sort(function (a, b) {
-            a = utils.isObject(a) ? utils.getPath(a, sortKey) : a
-            b = utils.isObject(b) ? utils.getPath(b, sortKey) : b
+            a = Vue.util.isObject(a) ? Vue.parsers.path.getPath(a, sortKey) : a
+            b = Vue.util.isObject(b) ? Vue.parsers.path.getPath(b, sortKey) : b
 
             a = a === undefined ? a : a.toLowerCase()
             b = b === undefined ? b : b.toLowerCase()

--- a/resources/assets/js/app.vue
+++ b/resources/assets/js/app.vue
@@ -28,6 +28,7 @@
     import settingStore from './stores/setting';
     import preferenceStore from './stores/preference';
     import playback from './services/playback';
+    import utils from './services/utils';
 
     export default {
         components: { siteHeader, siteFooter, mainWrapper, overlay },
@@ -181,6 +182,28 @@
             }
         },
     };
+
+    /**
+     * Modified version of orderBy that is case insensitive
+     *
+     * @source https://github.com/vuejs/vue/blob/dev/src/filters/array-filters.js
+     */
+    Vue.filter('caseInsensitiveOrderBy', function (arr, sortKey, reverse) {
+        if (!sortKey) {
+            return arr
+        }
+        var order = (reverse && reverse < 0) ? -1 : 1
+        // sort on a copy to avoid mutating original array
+        return arr.slice().sort(function (a, b) {
+            a = utils.isObject(a) ? utils.getPath(a, sortKey) : a
+            b = utils.isObject(b) ? utils.getPath(b, sortKey) : b
+
+            a = a === undefined ? a : a.toLowerCase()
+            b = b === undefined ? b : b.toLowerCase()
+
+            return a === b ? 0 : a > b ? order : -order
+        })
+    });
 
     // Register the global directives
     Vue.directive('koel-focus', require('./directives/focus'));

--- a/resources/assets/js/components/shared/song-list.vue
+++ b/resources/assets/js/components/shared/song-list.vue
@@ -31,7 +31,7 @@
             <tbody>
                 <tr
                     v-for="item in items 
-                        | orderBy sortKey order
+                        | caseInsensitiveOrderBy sortKey order
                         | filterBy q in 'title' 'album.name' 'album.artist.name' 
                         | limitBy numOfItems"
                     is="song-item" 

--- a/resources/assets/js/services/utils.js
+++ b/resources/assets/js/services/utils.js
@@ -26,36 +26,4 @@ export default {
 
         return (h === '00' ? '' : h + ':') + i + ':' + s;
     },
-
-    /**
-     * Quick object check - this is primarily used to tell
-     * Objects from primitive values when we know the value
-     * is a JSON-compliant type.
-     *
-     * Copied directly from Vue source
-     *
-     * @param {*} obj
-     * @return {Boolean}
-     */
-    isObject(obj) {
-         return obj !== null && typeof obj === 'object';
-    },
-
-    /**
-     * Get from an object from a path string
-     *
-     * Poor mimick of Vue's core getPath
-     *
-     * @param {Object} obj
-     * @param {String} path
-     */
-    getPath(obj, path) {
-        var paths = path.split('.');
-
-        for (var i = 0; i < paths.length; i++) {
-            obj = obj[paths[i]];
-        }
-
-        return obj;
-    },
 };

--- a/resources/assets/js/services/utils.js
+++ b/resources/assets/js/services/utils.js
@@ -26,4 +26,36 @@ export default {
 
         return (h === '00' ? '' : h + ':') + i + ':' + s;
     },
+
+    /**
+     * Quick object check - this is primarily used to tell
+     * Objects from primitive values when we know the value
+     * is a JSON-compliant type.
+     *
+     * Copied directly from Vue source
+     *
+     * @param {*} obj
+     * @return {Boolean}
+     */
+    isObject(obj) {
+         return obj !== null && typeof obj === 'object';
+    },
+
+    /**
+     * Get from an object from a path string
+     *
+     * Poor mimick of Vue's core getPath
+     *
+     * @param {Object} obj
+     * @param {String} path
+     */
+    getPath(obj, path) {
+        var paths = path.split('.');
+
+        for (var i = 0; i < paths.length; i++) {
+            obj = obj[paths[i]];
+        }
+
+        return obj;
+    },
 };


### PR DESCRIPTION
Prior to this PR being merged, the `orderBy` for columns is case sensitive. That means my list places lowercased-artist `mewithoutyou` after the entire list of Title-cased artists.

![image](https://cloud.githubusercontent.com/assets/151829/11790689/18538858-a26b-11e5-8b02-8871d72167b9.png)

After the change:

![image](https://cloud.githubusercontent.com/assets/151829/11790741/529ae47a-a26b-11e5-865a-fca6dd7d4060.png)

Heavy caveat: the hacked functions that I stole from Vue core are not quite as good as the core versions, but I couldn't figure out how to import core Vue functions. Maybe it's possible?