### PR TITLE
Queue media sync when media path is set

### DIFF
--- a/app/Events/MediaPathChanged.php
+++ b/app/Events/MediaPathChanged.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Events;
+
+use App\Events\Event;
+
+class MediaPathChanged extends Event
+{
+    /**
+     * Path to media files.
+     *
+     * @var string
+     */
+    public $mediaPath;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param string $mediaPath
+     *
+     * @return void
+     */
+    public function __construct($mediaPath)
+    {
+        $this->mediaPath = $mediaPath;
+    }
+}

--- a/app/Events/MediaPathChanged.php
+++ b/app/Events/MediaPathChanged.php
@@ -2,8 +2,6 @@
 
 namespace App\Events;
 
-use App\Events\Event;
-
 class MediaPathChanged extends Event
 {
     /**

--- a/app/Http/Controllers/API/SettingController.php
+++ b/app/Http/Controllers/API/SettingController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers\API;
 
-use App\Facades\Media;
+use App\Events\MediaPathChanged;
 use App\Http\Requests\API\SettingRequest;
 use App\Models\Setting;
 
@@ -20,9 +20,7 @@ class SettingController extends Controller
         // For right now there's only one setting to be saved
         Setting::set('media_path', rtrim(trim($request->input('media_path')), '/'));
 
-        // In a next version we should opt for a "MediaPathChanged" event,
-        // but let's just do this async now.
-        Media::sync();
+        event(new MediaPathChanged(Setting::get('media_path')));
 
         return response()->json();
     }

--- a/app/Listeners/SyncMediaListener.php
+++ b/app/Listeners/SyncMediaListener.php
@@ -11,7 +11,8 @@ class SyncMediaListener implements ShouldQueue
     /**
      * Handle the MediaPathChanged event.
      *
-     * @param  MediaPathChanged  $event
+     * @param MediaPathChanged $event
+     *
      * @return void
      */
     public function handle(MediaPathChanged $event)

--- a/app/Listeners/SyncMediaListener.php
+++ b/app/Listeners/SyncMediaListener.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\MediaPathChanged;
+use App\Facades\Media;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class SyncMediaListener implements ShouldQueue
+{
+    /**
+     * Handle the MediaPathChanged event.
+     *
+     * @param  MediaPathChanged  $event
+     * @return void
+     */
+    public function handle(MediaPathChanged $event)
+    {
+        Media::sync();
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -16,8 +16,8 @@ class EventServiceProvider extends ServiceProvider
      * @var array
      */
     protected $listen = [
-        'App\Events\SomeEvent' => [
-            'App\Listeners\EventListener',
+        'App\Events\MediaPathChanged' => [
+            'App\Listeners\SyncMediaListener',
         ],
     ];
 

--- a/tests/SettingTest.php
+++ b/tests/SettingTest.php
@@ -52,7 +52,7 @@ class SettingTest extends TestCase
 
         $this->actingAs($user)
             ->post('api/settings', [
-                'media_path' => $this->mediaPath . '/',
+                'media_path' => $this->mediaPath.'/',
             ])
             ->assertResponseOk();
 

--- a/tests/SettingTest.php
+++ b/tests/SettingTest.php
@@ -1,11 +1,13 @@
 <?php
 
 use App\Models\Setting;
+use App\Models\User;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
 
 class SettingTest extends TestCase
 {
-    use DatabaseTransactions;
+    use WithoutMiddleware, DatabaseTransactions;
 
     public function testSetSingleKeyValue()
     {
@@ -40,5 +42,20 @@ class SettingTest extends TestCase
 
         $this->assertEquals('bar', Setting::get('foo'));
         $this->assertEquals(['baz' => 'qux'], Setting::get('bar'));
+    }
+
+    public function testSetMediaPath()
+    {
+        $user = factory(User::class, 'admin')->create();
+
+        $this->expectsEvents(App\Events\MediaPathChanged::class);
+
+        $this->actingAs($user)
+            ->post('api/settings', [
+                'media_path' => $this->mediaPath . '/',
+            ])
+            ->assertResponseOk();
+
+        $this->assertEquals($this->mediaPath, Setting::get('media_path'));
     }
 }


### PR DESCRIPTION
Another commit motivated by a comment:

```
// In a next version we should opt for a "MediaPathChanged" event,
// but let's just do this async now.
```

I've included a test for this and manually tested also. Works fine on my end. Let me know is there are any changes you want me to make.