### PR TITLE
Fixed composer install --no-dev issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,15 +7,15 @@
     "require": {
         "php": ">=5.5.9",
         "laravel/framework": "5.1.*",
-        "james-heinrich/getid3": "^1.9"
+        "james-heinrich/getid3": "^1.9",
+        "phanan/cascading-config": "~2.0",
+        "barryvdh/laravel-ide-helper": "^2.1"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",
         "mockery/mockery": "0.9.*",
         "phpunit/phpunit": "~4.0",
-        "phpspec/phpspec": "~2.1",
-        "barryvdh/laravel-ide-helper": "^2.1",
-        "phanan/cascading-config": "~2.0"
+        "phpspec/phpspec": "~2.1"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
Error will not be thrown when <code>composer install --no-dev</code> or <code>composer update --no-dev</code> command is used.