### PR TITLE
Fix incorrect calculation of album length

### DIFF
--- a/resources/assets/js/stores/album.js
+++ b/resources/assets/js/stores/album.js
@@ -49,7 +49,7 @@ export default {
      * @return string The H:i:s format of the album.
      */
     getLength(album) {
-        album.length = _.reduce(album.songs, (length, song) => length + song.length, 0);
+        album.length = _.reduce(album.songs, (length, song) => length + _.parseInt(song.length), 0);
 
         return (album.fmtLength = utils.secondsToHis(album.length));
     },


### PR DESCRIPTION
The album length was not calculated correctly because it generated a concatenated string instead of the number of seconds.