### PR TITLE
BASE_URL env variable (reverse proxy support)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,10 @@ APP_ENV=local
 APP_DEBUG=true
 APP_KEY=SomeRandomString
 
+# Force a base URL (useful when behind reverse proxy for example).
+# Leave this empty to autodetect your domain.
+BASE_URL=
+
 # Username and password for the initial admin account
 # This info will be populated into the database during `php artisan db:seed`
 # After that, it can (and should) be removed from this .env file

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -1,5 +1,10 @@
 <?php
 
+$baseUrl = env('BASE_URL');
+if($baseUrl){
+    URL::forceRootUrl($baseUrl);
+}
+
 Route::get('login', 'Auth\AuthController@getLogin');
 Route::post('login', 'Auth\AuthController@postLogin');
 Route::get('logout', 'Auth\AuthController@getLogout');


### PR DESCRIPTION
When behind a reverse proxy URL's are generated with the internal domain rather than the external one. Which breaks features like the Last.fm connect callback.

Configure your external domain here and it will work as expected.