### PR TITLE
Added integration with browser history

### DIFF
--- a/resources/assets/js/app.vue
+++ b/resources/assets/js/app.vue
@@ -48,6 +48,9 @@
         ready() {
             this.showOverlay();
 
+            // Modify current browser history entry to store the first view (queue)
+            window.history.replaceState({view: 'queue'}, '', window.location.href);
+
             // Make the most important HTTP request to get all necessary data from the server.
             // Afterwards, init all mandatory stores and services.
             sharedStore.init(() => {
@@ -140,6 +143,17 @@
              * @param string view The view, which can be found under components/main-wrapper/main-content.
              */
             loadMainView(view) {
+                this.$broadcast('main-content-view:load', view);
+
+                window.history.pushState({view: view}, '', window.location.href);
+            },
+
+            /**
+             * Load (display) a main panel (view) but do NOT safe it in the browser history.
+             *
+             * @param string view The view, which can be found under components/main-wrapper/main-content.
+             */
+            loadMainViewNoHistory(view) {
                 this.$broadcast('main-content-view:load', view);
             },
 

--- a/resources/assets/js/app.vue
+++ b/resources/assets/js/app.vue
@@ -149,7 +149,7 @@
             },
 
             /**
-             * Load (display) a main panel (view) but do NOT safe it in the browser history.
+             * Load (display) a main panel (view) but do NOT save it in the browser history.
              *
              * @param string view The view, which can be found under components/main-wrapper/main-content.
              */

--- a/resources/assets/js/main.js
+++ b/resources/assets/js/main.js
@@ -9,4 +9,9 @@ Vue.config.debug = false;
 // Enter night,
 // Take my hand,
 // We're off to never never land.
-new Vue(require('./app.vue')).$mount('body');
+var vm = new Vue(require('./app.vue')).$mount('body');
+
+// Use the popstate event to add support for previous/next buttons
+window.onpopstate = function(e) {
+    vm.loadMainViewNoHistory(e.state.view);
+}


### PR DESCRIPTION
In [issue 158](https://github.com/phanan/koel/issues/158) Beanow requested support for using the previous and next button in the browser.

I've modified the loadMainView function to save the loaded view in the history state. A listener listening for the popstate event restores the requested view.