### PR TITLE
add DB_CONNECTION to example env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@ ADMIN_PASSWORD=
 # The maximum scan time, in seconds. Increase this if you have a huge library.
 APP_MAX_SCAN_TIME=600
 
-# The streaming method. 
+# The streaming method.
 # Can be either 'php' (default), 'x-sendfile', or 'x-accel-redirect'
 # See https://github.com/phanan/koel/wiki#streaming-music for more information.
 STREAMING_METHOD=php
@@ -21,6 +21,7 @@ STREAMING_METHOD=php
 LASTFM_API_KEY=
 LASTFM_API_SECRET=
 
+DB_CONNECTION=mysql      # See config/database.php for options.
 DB_HOST=localhost
 DB_DATABASE=homestead
 DB_USERNAME=homestead


### PR DESCRIPTION
Add DB_CONNECTION field to the example env with a pointer to the database
config file for db options to help save a few seconds of debugging for
those non-Laravel-savvy users [such as myself] looking to use a non-default
database.