### PR TITLE
Show highlight color when hovering over album and artist

### DIFF
--- a/resources/assets/js/components/shared/song-item.vue
+++ b/resources/assets/js/components/shared/song-item.vue
@@ -101,6 +101,22 @@
             min-width: 192px;
         }
 
+        .album {
+            a {
+                &:hover {
+                    color: $colorHighlight;
+                }
+            }
+        }
+
+        .artist {
+            a {
+                &:hover {
+                    color: $colorHighlight;
+                }
+            }
+        }
+
         .play {
             max-width: 32px;
             opacity: .5;


### PR DESCRIPTION
Since we can now click on the album and artist names in the list view to directly jump to it, it makes sense to use the highlight color when hovering over them.