### PR TITLE
Styles

### DIFF
--- a/resources/assets/js/components/main-wrapper/extra/index.vue
+++ b/resources/assets/js/components/main-wrapper/extra/index.vue
@@ -183,7 +183,7 @@
             z-index: 5;
 
             transform: translateX(100%);
-            transition: transform .3s ease-in;
+            transition: transform .3s $slideAnimation;
 
             &.showing {
                 transform: translateX(0);

--- a/resources/assets/js/components/main-wrapper/extra/index.vue
+++ b/resources/assets/js/components/main-wrapper/extra/index.vue
@@ -110,7 +110,6 @@
         padding: 24px 16px $footerHeight;
         background: $colorExtraBgr;
         max-height: calc(100vh - #{$headerHeight + $footerHeight});
-        display: none;
         color: $color2ndText;
         overflow: auto;
         -ms-overflow-style: -ms-autohiding-scrollbar;
@@ -176,16 +175,18 @@
 
         @media only screen and (max-width : 1024px) {
             position: fixed;
-            height: calc(100vh - #{$headerHeight + $footerHeight});
-            padding-bottom: $footerHeight; // make sure the footer can never overlap the content
-            width: $extraPanelWidth;
-            z-index: 5;
             top: $headerHeight;
-            right: -100%;
-            transition: right .3s ease-in;
+            right: 0;
+            height: calc(100vh - #{$headerHeight + $footerHeight});
+            width: $extraPanelWidth;
+            padding-bottom: $footerHeight; // make sure the footer can never overlap the content
+            z-index: 5;
+
+            transform: translateX(100%);
+            transition: transform .3s ease-in;
 
             &.showing {
-                right: 0;
+                transform: translateX(0);
             }
         }
 

--- a/resources/assets/js/components/main-wrapper/main-content/index.vue
+++ b/resources/assets/js/components/main-wrapper/main-content/index.vue
@@ -105,6 +105,7 @@
             align-items: center;
             align-content: stretch;
             display: flex;
+            line-height: 1em;
 
             span:first-child {
                 flex: 1;

--- a/resources/assets/js/components/main-wrapper/sidebar/index.vue
+++ b/resources/assets/js/components/main-wrapper/sidebar/index.vue
@@ -263,16 +263,17 @@
 
         @media only screen and (max-width : 667px) {
             position: fixed;
-            height: calc(100vh - #{$headerHeight + $footerHeight});
-            padding-bottom: $footerHeight; // make sure the footer can never overlap the content
-            width: 100%;
-            z-index: 99;
             top: $headerHeight;
-            left: -100%;
-            transition: left .3s ease-in;
+            height: calc(100vh - #{$headerHeight + $footerHeight});
+            width: 100%;
+            padding-bottom: $footerHeight; // make sure the footer can never overlap the content
+            z-index: 99;
+
+            transform: translateX(-100%);
+            transition: transform .3s ease-in;
 
             &.showing {
-                left: 0;
+                transform: translateX(0);
             }
         }
     }

--- a/resources/assets/js/components/main-wrapper/sidebar/index.vue
+++ b/resources/assets/js/components/main-wrapper/sidebar/index.vue
@@ -270,7 +270,7 @@
             z-index: 99;
 
             transform: translateX(-100%);
-            transition: transform .3s ease-in;
+            transition: transform .3s $slideAnimation;
 
             &.showing {
                 transform: translateX(0);

--- a/resources/assets/sass/partials/_vars.scss
+++ b/resources/assets/sass/partials/_vars.scss
@@ -35,3 +35,4 @@ $footerHeight: 64px;
 $mainHeadingHeight: 64px;
 
 $extraPanelWidth: 334px;
+$slideAnimation: cubic-bezier(0,0,0.3,1);


### PR DESCRIPTION
The commit messages should explain everything. I removed all the `left` and `right` properties which were being animated with transitions. This improves performance and I replaced them with `translateX`. Also, changed transitions to look more natural and fixed overlapping text on my tablet. Also, added some padding under the search box in mobile and tablet mode to prevent it from covering information.