### PR TITLE
feature/stream-flac

### DIFF
--- a/app/Http/Controllers/API/SongController.php
+++ b/app/Http/Controllers/API/SongController.php
@@ -20,8 +20,10 @@ class SongController extends Controller
      */
     public function play(Song $song)
     {
-        if (ends_with(mime_content_type($song->path), 'flac')) {
-            return (new TranscodingStreamer($song))->stream();
+        if (env('OUTPUT_BIT_RATE', 128) !== 'original') {
+            if (ends_with(mime_content_type($song->path), 'flac')) {
+                return (new TranscodingStreamer($song))->stream();
+            }
         }
 
         switch (env('STREAMING_METHOD')) {


### PR DESCRIPTION
I've added support for the `.env` `OUTPUT_BIT_RATE` variable to support 'original' which will prevent the transcoding of `FLAC` files. Although the current player doesn't support the FLAC format, I'm working on adding support not only for playback, but potential options for a user to 'export' or 'download' their songs through the UI (and additional future features that may require access to the original file).

Obviously the verbage of `original` is up for debate. Not sure the best wording here.