### PR TITLE
feature/filetypes

### DIFF
--- a/app/Http/Controllers/API/SongController.php
+++ b/app/Http/Controllers/API/SongController.php
@@ -18,10 +18,21 @@ class SongController extends Controller
      *
      * @param Song $song
      */
-    public function play(Song $song)
+    public function play(Song $song, $transcode = null, $bitrate = null)
     {
-        if (ends_with(mime_content_type($song->path), 'flac')) {
-            return (new TranscodingStreamer($song))->stream();
+        if (is_null($bitrate)) {
+            $bitrate = env('OUTPUT_BIT_RATE', 128);
+        }
+
+        // If transcode parameter isn't passed, the default is to only transcode flac
+        if (is_null($transcode) && ends_with(mime_content_type($song->path), 'flac')) {
+            $transcode = true;
+        } else {
+            $transcode = (bool) $transcode;
+        }
+
+        if ($transcode) {
+            return (new TranscodingStreamer($song, $bitrate, request()->input('time', 0)))->stream();
         }
 
         switch (env('STREAMING_METHOD')) {

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -22,7 +22,7 @@ Route::group(['prefix' => 'api', 'namespace' => 'API'], function () {
 
         Route::post('settings', 'SettingController@store');
 
-        Route::get('{song}/play', 'SongController@play');
+        Route::get('{song}/play/{transcode?}/{bitrate?}', 'SongController@play');
         Route::post('{song}/scrobble/{timestamp}', 'ScrobbleController@store')->where([
             'timestamp' => '\d+',
         ]);


### PR DESCRIPTION
As mentioned yesterday in a different PR, this adds support to better control which file types are transcoded by koel. At the same time, I've gone ahead and added config values to control which file types koel will sync and make available.

These config options are not only future proofing the API for features that could become available in the future, I believe they are also necessary to accommodate other projects that may use koel's backend and API without necessarily using the frontend.

They are only config values, so by default they don't change any behavior or how koel works, but they do allow koel to be used in more ways than those that may be limited by its UI's capabilities.