### PR TITLE
Prevent click and drag where not anticipated

### DIFF
--- a/resources/assets/js/components/main-wrapper/extra/album-info.vue
+++ b/resources/assets/js/components/main-wrapper/extra/album-info.vue
@@ -32,7 +32,9 @@
         </ul>
       </section>
 
-      <footer>Data &copy; <a target="_blank" :href="album.info.url">Last.fm</a></footer>
+      <footer>Data &copy;
+        <a onmousedown="return false" target="_blank" :href="album.info.url">Last.fm</a>
+      </footer>
     </div>
 
     <p class="none" v-else>No album information found.</p>

--- a/resources/assets/js/components/main-wrapper/extra/artist-info.vue
+++ b/resources/assets/js/components/main-wrapper/extra/artist-info.vue
@@ -22,7 +22,9 @@
       </div>
       <p class="none" v-else>This artist has no Last.fm biography – yet.</p>
 
-      <footer>Data &copy; <a target="_blank" :href="artist.info.url">Last.fm</a></footer>
+      <footer>Data &copy;
+        <a onmousedown="return false" target="_blank" :href="artist.info.url">Last.fm</a>
+      </footer>
     </div>
 
     <p class="none" v-else>Nothing can be found. This artist is a mystery.</p>

--- a/resources/assets/js/components/main-wrapper/extra/youtube.vue
+++ b/resources/assets/js/components/main-wrapper/extra/youtube.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="youtube-wrapper">
     <template v-if="videos && videos.length">
-      <a class="video" v-for="video in videos" href="#" @click.prevent="playYouTube(video.id.videoId)">
+      <a class="video" v-for="video in videos" onmousedown="return false" href="#" @click.prevent="playYouTube(video.id.videoId)">
         <div class="thumb">
           <img :src="video.snippet.thumbnails.default.url" width="90">
         </div>

--- a/resources/assets/js/components/main-wrapper/main-content/album.vue
+++ b/resources/assets/js/components/main-wrapper/main-content/album.vue
@@ -13,7 +13,7 @@
 
         <span class="meta" v-show="meta.songCount">
           by
-          <a class="artist" v-if="isNormalArtist" :href="'/#!/artist/' + album.artist.id">{{ album.artist.name }}</a>
+          <a class="artist" v-if="isNormalArtist" onmousedown="return false" :href="'/#!/artist/' + album.artist.id">{{ album.artist.name }}</a>
           <span class="nope" v-else>{{ album.artist.name }}</span>
           •
           {{ meta.songCount | pluralize('song') }}
@@ -22,11 +22,19 @@
 
           <template v-if="sharedState.useLastfm">
             •
-            <a href="#" @click.prevent="showInfo" title="View album's extra information">Info</a>
+            <a onmousedown="return false"
+              href="#" @click.prevent="showInfo"
+              title="View album's extra information">
+              Info
+              </a>
           </template>
           <template v-if="sharedState.allowDownload">
             •
-            <a href="#" @click.prevent="download" title="Download all songs in album">Download</a>
+            <a onmousedown="return false"
+              href="#" @click.prevent="download"
+              title="Download all songs in album">
+              Download
+              </a>
           </template>
         </span>
       </span>

--- a/resources/assets/js/components/main-wrapper/main-content/artist.vue
+++ b/resources/assets/js/components/main-wrapper/main-content/artist.vue
@@ -20,12 +20,20 @@
 
           <template v-if="sharedState.useLastfm">
             •
-            <a href="#" @click.prevent="showInfo" title="View artist's extra information">Info</a>
+            <a onmousedown="return false"
+              href="#" @click.prevent="showInfo"
+              title="View artist's extra information">
+              Info
+              </a>
           </template>
 
           <template v-if="sharedState.allowDownload">
             •
-            <a href="#" @click.prevent="download" title="Download all songs by this artist">Download</a>
+            <a onmousedown="return false"
+              href="#" @click.prevent="download"
+              title="Download all songs by this artist">
+              Download
+              </a>
           </template>
         </span>
       </span>

--- a/resources/assets/js/components/main-wrapper/main-content/favorites.vue
+++ b/resources/assets/js/components/main-wrapper/main-content/favorites.vue
@@ -15,7 +15,8 @@
           {{ meta.totalLength }}
           <template v-if="sharedState.allowDownload && state.songs.length">
             •
-            <a href="#" @click.prevent="download"
+            <a onmousedown="return false"
+              href="#" @click.prevent="download"
               title="Download all songs in playlist">
               Download
             </a>

--- a/resources/assets/js/components/main-wrapper/main-content/playlist.vue
+++ b/resources/assets/js/components/main-wrapper/main-content/playlist.vue
@@ -16,6 +16,7 @@
           <template v-if="sharedState.allowDownload && playlist.songs.length">
             •
             <a href="#" @click.prevent="download"
+              onmousedown="return false"
               title="Download all songs in playlist">
               Download
             </a>

--- a/resources/assets/js/components/main-wrapper/main-content/profile.vue
+++ b/resources/assets/js/components/main-wrapper/main-content/profile.vue
@@ -93,7 +93,10 @@
         <div v-else>
           <p>This installation of Koel has no Last.fm integration.
             <span v-if="state.current.is_admin">Visit
-              <a href="https://github.com/phanan/koel/wiki" target="_blank">Koel’s Wiki</a>
+              <a onmousedown="return false"
+                href="https://github.com/phanan/koel/wiki" target="_blank">
+                Koel’s Wiki
+                </a>
               for a quick how-to. Really, you should do it.
             </span>
             <span v-else>Try politely asking your adminstrator to enable it.</span>

--- a/resources/assets/js/components/main-wrapper/sidebar/index.vue
+++ b/resources/assets/js/components/main-wrapper/sidebar/index.vue
@@ -5,27 +5,43 @@
 
       <ul class="menu">
         <li>
-          <a class="home" :class="[currentView == 'home' ? 'active' : '']" href="/#!/home">Home</a>
+          <a class="home"
+            :class="[currentView == 'home' ? 'active' : '']"
+            onmousedown="return false"
+            href="/#!/home">Home</a>
         </li>
         <li>
           <a class="queue"
             :class="[currentView == 'queue' ? 'active' : '']"
+            onmousedown="return false"
             href="/#!/queue"
             @dragleave="removeDroppableState"
             @dragover.prevent="allowDrop"
             @drop.stop.prevent="handleDrop">Current Queue</a>
         </li>
         <li>
-          <a class="songs" :class="[currentView == 'songs' ? 'active' : '']" href="/#!/songs">All Songs</a>
+          <a class="songs"
+            :class="[currentView == 'songs' ? 'active' : '']"
+            onmousedown="return false"
+            href="/#!/songs">All Songs</a>
         </li>
         <li>
-          <a class="albums" :class="[currentView == 'albums' ? 'active' : '']" href="/#!/albums">Albums</a>
+          <a class="albums"
+            :class="[currentView == 'albums' ? 'active' : '']"
+            onmousedown="return false"
+            href="/#!/albums">Albums</a>
         </li>
         <li>
-          <a class="artists" :class="[currentView == 'artists' ? 'active' : '']" href="/#!/artists">Artists</a>
+          <a class="artists"
+            :class="[currentView == 'artists' ? 'active' : '']"
+            onmousedown="return false"
+            href="/#!/artists">Artists</a>
         </li>
         <li v-if="sharedState.useYouTube">
-          <a class="youtube" :class="[currentView == 'youtubePlayer' ? 'active' : '']" href="/#!/youtube">YouTube Video</a>
+          <a class="youtube"
+            :class="[currentView == 'youtubePlayer' ? 'active' : '']"
+            onmousedown="return false"
+            href="/#!/youtube">YouTube Video</a>
         </li>
       </ul>
     </section>
@@ -37,10 +53,16 @@
 
       <ul class="menu">
         <li>
-          <a class="settings" :class="[currentView == 'settings' ? 'active' : '']" href="/#!/settings">Settings</a>
+          <a class="settings"
+            :class="[currentView == 'settings' ? 'active' : '']"
+            onmousedown="return false"
+            href="/#!/settings">Settings</a>
         </li>
         <li>
-          <a class="users" :class="[currentView == 'users' ? 'active' : '']" href="/#!/users">Users</a>
+          <a class="users"
+            :class="[currentView == 'users' ? 'active' : '']"
+            onmousedown="return false"
+            href="/#!/users">Users</a>
         </li>
       </ul>
     </section>
@@ -49,7 +71,8 @@
       :href="'https://github.com/phanan/koel/releases/tag/' + sharedState.latestVersion"
       target="_blank"
       v-if="user.current.is_admin && sharedState.currentVersion < sharedState.latestVersion"
-      class="new-ver">
+      class="new-ver"
+      onmousedown="return false">
       Koel version {{ sharedState.latestVersion }} is available!
     </a>
   </nav>

--- a/resources/assets/js/components/main-wrapper/sidebar/playlist-item.vue
+++ b/resources/assets/js/components/main-wrapper/sidebar/playlist-item.vue
@@ -1,6 +1,7 @@
 <template>
   <li @dblclick.prevent="edit" class="playlist" :class="[type, editing ? 'editing' : '']">
     <a :href="isFavorites ? '/#!/favorites' : '/#!/playlist/' + playlist.id"
+      onmousedown="return false"
       @dragleave="removeDroppableState"
       @dragover.prevent="allowDrop"
       @drop.stop.prevent="handleDrop"

--- a/resources/assets/js/components/shared/user-item.vue
+++ b/resources/assets/js/components/shared/user-item.vue
@@ -1,7 +1,7 @@
 <template>
   <article class="user-item" :class="{ editing: editing }">
     <div class="info" v-if="!editing">
-      <img :src="user.avatar" width="128" height="128" alt="">
+      <img onmousedown="return false" :src="user.avatar" width="128" height="128" alt="">
 
       <div class="right">
         <div>

--- a/resources/assets/js/components/site-footer/index.vue
+++ b/resources/assets/js/components/site-footer/index.vue
@@ -24,8 +24,12 @@
         <div class="progress" id="progressPane">
           <h3 class="title">{{ song.title }}</h3>
           <p class="meta">
-            <a class="artist" :href="'/#!/artist/' + song.artist.id">{{ song.artist.name }}</a> –
-            <a class="album" :href="'/#!/album/' + song.album.id">{{ song.album.name }}</a>
+            <a class="artist"
+              onmousedown="return false"
+              :href="'/#!/artist/' + song.artist.id">{{ song.artist.name }}</a> –
+            <a class="album"
+              onmousedown="return false"
+              :href="'/#!/album/' + song.album.id">{{ song.album.name }}</a>
           </p>
 
           <div class="plyr">

--- a/resources/assets/js/components/site-header/user-badge.vue
+++ b/resources/assets/js/components/site-header/user-badge.vue
@@ -1,6 +1,6 @@
 <template>
   <span class="profile" id="userBadge">
-    <a class="view-profile control" href="/#!/profile">
+    <a class="view-profile control" onmousedown="return false" href="/#!/profile">
       <img class="avatar" :src="state.current.avatar" alt="Avatar"></img>
       <span class="name">{{ state.current.name }}</span>
     </a>


### PR DESCRIPTION
It would happen on occasion that I would mistakenly click and drag items, and if if drag it over a droppable item things would break.

To reproduce this, click and drag the home item on to current queue. The solution is to return false on mouse click down.
![image](https://cloud.githubusercontent.com/assets/10334679/17351040/63977082-58f9-11e6-864b-13666c1551da.png)


I tested it on Windows & iPhone6S the Opera browser and everything if functioning fine after the changes, including clicking and dragging items into the queue.

Besides for th occasional issues it was causing, I believe that it makes the App nicer in general when you don't have weird dragable things in it.

I hope you approve, I tried sticking to your format on things. I'm not a professional programmer which means that there might be a better way to do it.