### PR TITLE
Allow music library scanning to follow symbolic links 

### DIFF
--- a/app/Services/Media.php
+++ b/app/Services/Media.php
@@ -113,6 +113,7 @@ class Media
         return Finder::create()
             ->ignoreUnreadableDirs()
             ->files()
+            ->followLinks()
             ->name('/\.(mp3|ogg|m4a|flac)$/i')
             ->in($path);
     }


### PR DESCRIPTION
By default, Koel does not follow symbolic links while scanning the music library (see issue #389). This is unfortunate for 2 reasons:

1. Koel does not allow adding multiple music library path (so it's not possible to have *per-user* music library), thus all users will see the same music library (and obviously, the most limited one).
2. It's possible to simulate the feature by adding symbolic links in the music library so it points to the user's folder (any users will see the music from all users), but without this patch, it does not work.

I'm not sure what should be the ideal solution for point 1, because if we have multiple path to to the music library, then it also means setting some kind of permission from cross-users access to the library and their personal library. At least with point 2, it's a "gather the world in peace" solution, even if not perfect.