### PR TITLE
Allow failure reason to be reported in verbose mode 

### DIFF
--- a/app/Console/Commands/SyncMedia.php
+++ b/app/Console/Commands/SyncMedia.php
@@ -103,8 +103,9 @@ class SyncMedia extends Command
      *
      * @param string $path
      * @param mixed  $result
+     * @param string $reason
      */
-    public function logToConsole($path, $result)
+    public function logToConsole($path, $result, $reason = '')
     {
         $name = basename($path);
 
@@ -116,7 +117,7 @@ class SyncMedia extends Command
             ++$this->ignored;
         } elseif ($result === false) {
             if ($this->option('verbose')) {
-                $this->error("$name is not a valid media file");
+                $this->error("$name is not a valid media file because: ".$reason);
             }
 
             ++$this->invalid;

--- a/app/Models/File.php
+++ b/app/Models/File.php
@@ -57,6 +57,13 @@ class File
     protected $song;
 
     /**
+     * The last parsing error text, if any.
+     *
+     * @var string
+     */
+    protected $syncError;
+
+    /**
      * Construct our File object.
      * Upon construction, we'll set the path, hash, and associated Song object (if any).
      *
@@ -81,6 +88,7 @@ class File
         $this->path = $this->splFileInfo->getPathname();
         $this->hash = self::getHash($this->path);
         $this->song = Song::find($this->hash);
+        $this->syncError = '';
     }
 
     /**
@@ -93,6 +101,8 @@ class File
         $info = $this->getID3->analyze($this->path);
 
         if (isset($info['error']) || !isset($info['playtime_seconds'])) {
+            $this->syncError = isset($info['error']) ? $info['error'][0] : 'No playtime found';
+
             return;
         }
 
@@ -304,6 +314,16 @@ class File
     public function getGetID3()
     {
         return $this->getID3;
+    }
+
+    /**
+     * Get the last parsing error's text.
+     *
+     * @return syncError
+     */
+    public function getSyncError()
+    {
+        return $this->syncError;
     }
 
     /**

--- a/app/Services/Media.php
+++ b/app/Services/Media.php
@@ -93,7 +93,7 @@ class Media
 
             if ($syncCommand) {
                 $syncCommand->updateProgressBar();
-                $syncCommand->logToConsole($file->getPath(), $song);
+                $syncCommand->logToConsole($file->getPath(), $song, $file->getSyncError());
             }
         }
 


### PR DESCRIPTION
Currently, when the parser chokes on a file, it's counted as a "bad" file, and reported as so. 
Yet, we don't know the reason for the failure.
This patch implements this, it uncovers the failure reason from the parser, so the user could act accordingly to fix the issue.

Fix #405