### PR TITLE
Populate dotenv to config

### DIFF
--- a/app/Application.php
+++ b/app/Application.php
@@ -68,7 +68,7 @@ class Application extends IlluminateApplication
      */
     public function staticUrl($name = null)
     {
-        $cdnUrl = trim(env('CDN_URL'), '/ ');
+        $cdnUrl = trim(config('koel.cdn.url'), '/ ');
 
         return $cdnUrl ? $cdnUrl.'/'.trim(ltrim($name, '/')) : trim(asset($name));
     }

--- a/app/Console/Commands/Init.php
+++ b/app/Console/Commands/Init.php
@@ -44,14 +44,14 @@ class Init extends Command
         $this->comment('Remember, you can always install/upgrade manually following the guide here:');
         $this->info("📙  https://github.com/phanan/koel/wiki\n");
 
-        if (!env('APP_KEY')) {
+        if (!config('app.key')) {
             $this->info('Generating app key');
             Artisan::call('key:generate');
         } else {
             $this->comment('App key exists -- skipping');
         }
 
-        if (!env('JWT_SECRET')) {
+        if (!config('jwt.secret')) {
             $this->info('Generating JWT secret');
             Artisan::call('koel:generate-jwt-secret');
         } else {

--- a/app/Http/Controllers/API/DataController.php
+++ b/app/Http/Controllers/API/DataController.php
@@ -36,7 +36,7 @@ class DataController extends Controller
             'currentUser' => auth()->user(),
             'useLastfm' => Lastfm::used(),
             'useYouTube' => YouTube::enabled(),
-            'allowDownload' =>  env('ALLOW_DOWNLOAD', true),
+            'allowDownload' =>  config('koel.download.allow'),
             'cdnUrl' => app()->staticUrl(),
             'currentVersion' => Application::VERSION,
             'latestVersion' => auth()->user()->is_admin ? app()->getLatestVersion() : Application::VERSION,

--- a/app/Http/Controllers/API/SongController.php
+++ b/app/Http/Controllers/API/SongController.php
@@ -40,11 +40,11 @@ class SongController extends Controller
         if ($transcode) {
             $streamer = new TranscodingStreamer(
                 $song,
-                $bitRate ? $bitRate : env('OUTPUT_BIT_RATE', 128),
+                $bitRate ? $bitRate : config('koel.streaming.bitrate'),
                 request()->input('time', 0)
             );
         } else {
-            switch (env('STREAMING_METHOD')) {
+            switch (config('koel.streming.method')) {
                 case 'x-sendfile':
                     $streamer = new XSendFileStreamer($song);
                     break;

--- a/app/Http/Controllers/API/SongController.php
+++ b/app/Http/Controllers/API/SongController.php
@@ -40,7 +40,7 @@ class SongController extends Controller
         if ($transcode) {
             $streamer = new TranscodingStreamer(
                 $song,
-                $bitRate ? $bitRate : config('koel.streaming.bitrate'),
+                $bitRate ?: config('koel.streaming.bitrate'),
                 request()->input('time', 0)
             );
         } else {

--- a/app/Http/Requests/API/Download/Request.php
+++ b/app/Http/Requests/API/Download/Request.php
@@ -13,7 +13,7 @@ class Request extends BaseRequest
      */
     public function authorize()
     {
-        return env('ALLOW_DOWNLOAD', true);
+        return config('koel.download.allow');
     }
 
     public function rules()

--- a/app/Http/Streamers/TranscodingStreamer.php
+++ b/app/Http/Streamers/TranscodingStreamer.php
@@ -32,7 +32,7 @@ class TranscodingStreamer extends Streamer implements StreamerInterface
      */
     public function stream()
     {
-        $ffmpeg = env('FFMPEG_PATH', '/usr/local/bin/ffmpeg');
+        $ffmpeg = config('koel.streaming.transcoding');
         abort_unless(is_executable($ffmpeg), 500, 'Transcoding requires valid ffmpeg settings.');
 
         $bitRate = filter_var($this->bitRate, FILTER_SANITIZE_NUMBER_INT);

--- a/app/Services/Lastfm.php
+++ b/app/Services/Lastfm.php
@@ -33,8 +33,8 @@ class Lastfm extends RESTfulService
     public function __construct($key = null, $secret = null, Client $client = null)
     {
         parent::__construct(
-            $key ?: env('LASTFM_API_KEY'),
-            $secret ?: env('LASTFM_API_SECRET'),
+            $key ?: config('koel.lastfm.key'),
+            $secret ?: config('koel.lastfm.secret'),
             'https://ws.audioscrobbler.com/2.0',
             $client ?: new Client()
         );
@@ -47,7 +47,7 @@ class Lastfm extends RESTfulService
      */
     public function used()
     {
-        return env('LASTFM_API_KEY') && env('LASTFM_API_SECRET');
+        return config('koel.lastfm.key') && config('koel.lastfm.secret');
     }
 
     /**

--- a/app/Services/Media.php
+++ b/app/Services/Media.php
@@ -58,7 +58,7 @@ class Media
     public function sync($path = null, $tags = [], $force = false, SyncMedia $syncCommand = null)
     {
         if (!app()->runningInConsole()) {
-            set_time_limit(env('APP_MAX_SCAN_TIME', 600));
+            set_time_limit(config('koel.sync.timeout'));
         }
 
         $path = $path ?: Setting::get('media_path');

--- a/app/Services/YouTube.php
+++ b/app/Services/YouTube.php
@@ -17,7 +17,7 @@ class YouTube extends RESTfulService
     public function __construct($key = null, Client $client = null)
     {
         parent::__construct(
-            $key ?: env('YOUTUBE_API_KEY'),
+            $key ?: config('koel.youtube.key'),
             null,
             'https://www.googleapis.com/youtube/v3',
             $client ?: new Client()
@@ -31,7 +31,7 @@ class YouTube extends RESTfulService
      */
     public function enabled()
     {
-        return (bool) env('YOUTUBE_API_KEY');
+        return (bool) config('koel.youtube.key');
     }
 
     /**

--- a/config/jwt.php
+++ b/config/jwt.php
@@ -146,9 +146,7 @@ return [
         |
         */
 
-        'auth' => function ($app) {
-            return new Tymon\JWTAuth\Providers\Auth\IlluminateAuthAdapter($app['auth']);
-        },
+        'auth' => 'Tymon\JWTAuth\Providers\Auth\IlluminateAuthAdapter',
 
         /*
         |--------------------------------------------------------------------------
@@ -159,9 +157,7 @@ return [
         |
         */
 
-        'storage' => function ($app) {
-            return new Tymon\JWTAuth\Providers\Storage\IlluminateCacheAdapter($app['cache']);
-        },
+        'storage' => 'Tymon\JWTAuth\Providers\Storage\IlluminateCacheAdapter',
 
     ],
 

--- a/config/koel.php
+++ b/config/koel.php
@@ -1,6 +1,24 @@
 <?php
 
+    /*
+    |--------------------------------------------------------------------------
+    | Koel Environment Configuration
+    |--------------------------------------------------------------------------
+    |
+    | The Confiuration options below are specific to the Koel APP
+    |
+    */
+
 return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Admin Credentials
+    |--------------------------------------------------------------------------
+    |
+    | When running `php artisan koel:init` the admin is set using the .env
+    |
+    */
 
     'admin'     => [
         'name'  => env('ADMIN_NAME'),
@@ -8,9 +26,29 @@ return [
     'password'  => env('ADMIN_PASSWORD'),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Sync Options
+    |--------------------------------------------------------------------------
+    |
+    | A timeout is set when using the browser to scan the folder path
+    |
+    */
+
     'sync'      => [
     'timeout'   => env('APP_MAX_SCAN_TIME', 600),
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Streaming Configurations
+    |--------------------------------------------------------------------------
+    |
+    | Many streaming options can be set, including, 'bitrate' with 128 set
+    | as the default, 'method' with php as the default and 'transcoding'
+    | to configure the path for FFMPEG to transcode FLAC audio files
+    |
+    */
 
     'streaming' => [
         'bitrate'   => env('OUTPUT_BIT_RATE', 128),
@@ -18,18 +56,54 @@ return [
     'transcoding'   => env('FFMPEG_PATH', '/usr/local/bin/ffmpeg'),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Youtube Integration
+    |--------------------------------------------------------------------------
+    |
+    | Youtube integration requires an youtube API key, see wiki for more
+    |
+    */
+
     'youtube'   => [
         'key'   => env('YOUTUBE_API_KEY'),
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Last.FM Integration
+    |--------------------------------------------------------------------------
+    |
+    | See wiki on how to integrate with Last.FM
+    |
+    */
 
     'lastfm'    => [
         'key'   => env('LASTFM_API_KEY'),
     'secret'    => env('LASTFM_API_SECRET'),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | CDN
+    |--------------------------------------------------------------------------
+    |
+    |
+    |
+    */
+
     'cdn'       => [
         'url'   => env('CDN_URL'),
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Downloading Music
+    |--------------------------------------------------------------------------
+    |
+    | Koel provides the ability to prohibit or allow [default] downloading music
+    |
+    */
 
     'download'  => [
         'allow' => env('ALLOW_DOWNLOAD', true),

--- a/config/koel.php
+++ b/config/koel.php
@@ -1,0 +1,38 @@
+<?php
+
+return [
+
+    'admin'     => [
+        'name'  => env('ADMIN_NAME'),
+        'email' => env('ADMIN_EMAIL'),
+    'password'  => env('ADMIN_PASSWORD'),
+    ],
+
+    'sync'      => [
+    'timeout'   => env('APP_MAX_SCAN_TIME', 600),
+    ],
+
+    'streaming' => [
+        'bitrate'   => env('OUTPUT_BIT_RATE', 128),
+        'method'    => env('STREAMING_METHOD'),
+    'transcoding'   => env('FFMPEG_PATH', '/usr/local/bin/ffmpeg'),
+    ],
+
+    'youtube'   => [
+        'key'   => env('YOUTUBE_API_KEY'),
+    ],
+
+    'lastfm'    => [
+        'key'   => env('LASTFM_API_KEY'),
+    'secret'    => env('LASTFM_API_SECRET'),
+    ],
+
+    'cdn'       => [
+        'url'   => env('CDN_URL'),
+    ],
+
+    'download'  => [
+        'allow' => env('ALLOW_DOWNLOAD', true),
+    ],
+
+];

--- a/database/seeds/UserTableSeeder.php
+++ b/database/seeds/UserTableSeeder.php
@@ -10,15 +10,18 @@ class UserTableSeeder extends Seeder
      */
     public function run()
     {
-        if (!env('ADMIN_NAME') || !env('ADMIN_EMAIL') || !env('ADMIN_PASSWORD')) {
+        if (!config('koel.admin.name') ||
+            !config('koel.admin.email') ||
+            !config('koel.admin.password'))
+        {
             $this->command->error('Please fill in initial admin details in .env file first.');
             abort(422);
         }
 
         User::create([
-            'name' => env('ADMIN_NAME'),
-            'email' => env('ADMIN_EMAIL'),
-            'password' => Hash::make(env('ADMIN_PASSWORD')),
+            'name' => config('koel.admin.name'),
+            'email' => config('koel.admin.email'),
+            'password' => Hash::make(config('koel.admin.password')),
             'is_admin' => true,
         ]);
 

--- a/database/seeds/UserTableSeeder.php
+++ b/database/seeds/UserTableSeeder.php
@@ -14,15 +14,15 @@ class UserTableSeeder extends Seeder
             'is_admin' => true,
         ]);
 
-        if (! app()->runningUnitTests()) {
-        $this->command->info('Admin user created. You can (and should) remove the auth details from .env now.');
+        if (!app()->runningUnitTests()) {
+            $this->command->info('Admin user created. You can (and should) remove the auth details from .env now.');
         }
     }
 
     protected function getUserDetails()
     {
         $details = array_filter(array_only(config('koel.admin', []), [
-            'name', 'email', 'password'
+            'name', 'email', 'password',
         ]));
 
         if (count($details) != 3) {

--- a/database/seeds/UserTableSeeder.php
+++ b/database/seeds/UserTableSeeder.php
@@ -10,23 +10,27 @@ class UserTableSeeder extends Seeder
      */
     public function run()
     {
-        if (!config('koel.admin.name') ||
-            !config('koel.admin.email') ||
-            !config('koel.admin.password'))
-        {
-            $this->command->error('Please fill in initial admin details in .env file first.');
-            abort(422);
-        }
-
-        User::create([
-            'name' => config('koel.admin.name'),
-            'email' => config('koel.admin.email'),
-            'password' => Hash::make(config('koel.admin.password')),
+        User::create($this->getUserDetails() + [
             'is_admin' => true,
         ]);
 
-        if (app()->environment() !== 'testing') {
-            $this->command->info('Admin user created. You can (and should) remove the auth details from .env now.');
+        if (! app()->runningUnitTests()) {
+        $this->command->info('Admin user created. You can (and should) remove the auth details from .env now.');
         }
+    }
+
+    protected function getUserDetails()
+    {
+        $details = array_filter(array_only(config('koel.admin', []), [
+            'name', 'email', 'password'
+        ]));
+
+        if (count($details) != 3) {
+            $this->command->error('Please fill in initial admin details in .env file first.');
+
+            abort(422);
+        }
+
+        return $details;
     }
 }


### PR DESCRIPTION
I noticed that occasionally I would have an error
```
[2016-08-10 00:23:08] production.ERROR: PDOException: SQLSTATE[HY000] [1045] Access denied for user 'forge'@'localhost' (using password: NO) in C:\wamp64\www\koel\vendor\laravel\framework\src\Illuminate\Database\Connectors\Connector.php:55
```
of course this make no sense since I have set the DB and password.

So I did some research and found 2 things

1. dotenv should only be used in development, once in production it should all be cached.
2. dotenv should only be populated in the config directory.

Here is a post https://github.com/vlucas/phpdotenv/issues/76#issuecomment-167806230 by @GrahamCampbell about this.

In this PR I created a separate config file `koel.php` for all Koel specific configurations, and I also fix https://github.com/phanan/koel/issues/408.

Going forward we can tell users to run `php artisan config:cache` once they finnished setting up Koel, or we could even make part of the `koel:init` command.

**Note**

I think this might in fact be the actual issue with https://github.com/phanan/koel/issues/393.