### PR TITLE
Fix for cover albums not found

### DIFF
--- a/app/Models/File.php
+++ b/app/Models/File.php
@@ -345,6 +345,7 @@ class File
                 ->depth(0)
                 ->ignoreUnreadableDirs()
                 ->files()
+                ->followLinks()
                 ->name('/(cov|fold)er\.(jpe?g|png)$/i')
                 ->in(dirname($this->path))
         ));


### PR DESCRIPTION
Fix #412
Forgot to add this in the previous patch that allowed symbolic links