### PR TITLE
Split settings saving from media library synchronization

### DIFF
--- a/app/Http/Controllers/API/SettingController.php
+++ b/app/Http/Controllers/API/SettingController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers\API;
 
-use App\Facades\Media;
 use App\Http\Requests\API\SettingRequest;
 use App\Models\Setting;
 
@@ -20,10 +19,7 @@ class SettingController extends Controller
         // For right now there's only one setting to be saved
         Setting::set('media_path', rtrim(trim($request->input('media_path')), '/'));
 
-        // In a next version we should opt for a "MediaPathChanged" event,
-        // but let's just do this async now.
-        Media::sync();
-
+        // Changing the settings does not force scanning the library anymore
         return response()->json();
     }
 }

--- a/app/Http/Controllers/API/SyncController.php
+++ b/app/Http/Controllers/API/SyncController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Facades\Media;
+use App\Http\Requests\API\SyncRequest;
+
+class SyncController extends Controller
+{
+    /**
+     * Synchronize the library.
+     *
+     * @param Request $request
+     * @param bool    $force
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function sync(SyncRequest $request, $force = false)
+    {
+        // In a next version we should opt for a echo system,
+        // but let's just do this async now.
+        $results = Media::sync();
+
+        return response()->json();
+    }
+}

--- a/app/Http/Requests/API/SyncRequest.php
+++ b/app/Http/Requests/API/SyncRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests\API;
+
+class SyncRequest extends Request
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     * Currently, only user with admin rights are allowed to do this.
+     * When per-user media library will be available, this restriction will be removed.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return auth()->user()->is_admin;
+    }
+
+    /**
+     * Get the validation rules that apply to the request (currently none).
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -21,6 +21,7 @@ Route::group(['prefix' => 'api', 'namespace' => 'API'], function () {
         Route::get('data', 'DataController@index');
 
         Route::post('settings', 'SettingController@store');
+        Route::post('syncLibrary/{force?}', 'SyncController@sync');
 
         Route::get('{song}/play/{transcode?}/{bitrate?}', 'SongController@play');
         Route::post('{song}/scrobble/{timestamp}', 'ScrobbleController@store')->where([

--- a/app/Models/File.php
+++ b/app/Models/File.php
@@ -327,6 +327,16 @@ class File
     }
 
     /**
+     * Set the last parsing error's text.
+     *
+     * @param string $msg The error message
+     */
+    public function setSyncError($msg)
+    {
+        $this->syncError = $msg;
+    }
+
+    /**
      * @param getID3 $getID3
      */
     public function setGetID3($getID3 = null)

--- a/tests/SettingTest.php
+++ b/tests/SettingTest.php
@@ -46,8 +46,6 @@ class SettingTest extends TestCase
 
     public function testApplicationSetting()
     {
-        Media::shouldReceive('sync')->once();
-
         $dir = dirname(__FILE__);
         $this->actingAs(factory(User::class, 'admin')->create())
             ->post('/api/settings', ['media_path' => $dir])

--- a/tests/SyncTest.php
+++ b/tests/SyncTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+
+class SyncTest extends TestCase
+{
+    use WithoutMiddleware;
+
+    public function testSyncLibrary()
+    {
+        Media::shouldReceive('sync')->once();
+
+        $this->actingAs(factory(User::class, 'admin')->create())
+            ->post('/api/syncLibrary', [])
+            ->seeStatusCode(200);
+    }
+}


### PR DESCRIPTION
The former is a change to the DB config (instantaneous), the later an (possibly long) action.
Because of the processing time to sync the complete media library path, and the running time limit imposed by the webserver (which can no be modified without side effects), the sync' failed, and returns an error to the user who thinks the settings could not be saved instead because the UI says "Save settings" (and only if the user waited for the timeout...) 