### PR TITLE
Remove phpunit from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
     "require-dev": {
         "fzaninotto/faker": "~1.4",
         "mockery/mockery": "0.9.*",
-        "phpunit/phpunit": "~4.0",
         "phpspec/phpspec": "~2.1",
         "symfony/css-selector": "2.8.*|3.0.*",
         "symfony/dom-crawler": "2.8.*|3.0.*"


### PR DESCRIPTION
The version of phpunit required is based on the php version the system is running, for PHP7 it needs to be version 5 and for PHP 5.5 phpunit 4.8

The better option is to have users do  `composer global require "phpunit/phpunit=5.5.*"` or `composer global require "phpunit/phpunit=4.8.*"`

[Here are the phpunit version 5 release notes](https://github.com/sebastianbergmann/phpunit/wiki/Release-Announcement-for-PHPUnit-5.0.0).