### PR TITLE
Render html em tag

### DIFF
--- a/resources/assets/sass/partials/_shared.scss
+++ b/resources/assets/sass/partials/_shared.scss
@@ -120,6 +120,10 @@ p {
   line-height: 1.5rem;
 }
 
+em {
+  font-style: italic;
+}
+
 .help {
   opacity: .7;
   font-size: .9rem;


### PR DESCRIPTION
I noticed that  in the settings page the em tag on the word absolute is not being rendered.