### PR TITLE
Add admin creds to unit testing

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -27,5 +27,8 @@
         <env name="LASTFM_API_KEY" value="foo"/>
         <env name="LASTFM_API_SECRET" value="bar"/>
         <env name="YOUTUBE_API_KEY" value="foo"/>
+        <env name="ADMIN_EMAIL" value="koel@example.com"/>
+        <env name="ADMIN_NAME" value="Koel"/>
+        <env name="ADMIN_PASSWORD" value="SoSecureK0el"/>
     </php>
 </phpunit>


### PR DESCRIPTION
When I was runing unit tests I was receiving HTTP error exceptions because there was no admin creds configured.

```php
1) ApplicationTest::testStaticUrlWithoutCDN
Symfony\Component\HttpKernel\Exception\HttpException:

C:\wamp64\www\koel\vendor\laravel\framework\src\Illuminate\Foundation\Application.php:882
C:\wamp64\www\koel\vendor\laravel\framework\src\Illuminate\Foundation\helpers.php:30
C:\wamp64\www\koel\database\seeds\UserTableSeeder.php:31
C:\wamp64\www\koel\database\seeds\UserTableSeeder.php:13
C:\wamp64\www\koel\vendor\laravel\framework\src\Illuminate\Database\Seeder.php:39
C:\wamp64\www\koel\database\seeds\DatabaseSeeder.php:16
C:\wamp64\www\koel\vendor\laravel\framework\src\Illuminate\Database\Console\Seeds\SeedCommand.php:63
C:\wamp64\www\koel\vendor\laravel\framework\src\Illuminate\Database\Eloquent\Model.php:2285
C:\wamp64\www\koel\vendor\laravel\framework\src\Illuminate\Database\Console\Seeds\SeedCommand.php:64
C:\wamp64\www\koel\vendor\laravel\framework\src\Illuminate\Container\Container.php:507
C:\wamp64\www\koel\vendor\laravel\framework\src\Illuminate\Console\Command.php:169
C:\wamp64\www\koel\vendor\symfony\console\Command\Command.php:256
C:\wamp64\www\koel\vendor\laravel\framework\src\Illuminate\Console\Command.php:155
C:\wamp64\www\koel\vendor\symfony\console\Application.php:791
C:\wamp64\www\koel\vendor\symfony\console\Application.php:186
C:\wamp64\www\koel\vendor\symfony\console\Application.php:117
C:\wamp64\www\koel\vendor\laravel\framework\src\Illuminate\Console\Application.php:64
C:\wamp64\www\koel\vendor\laravel\framework\src\Illuminate\Foundation\Console\Kernel.php:159
C:\wamp64\www\koel\vendor\laravel\framework\src\Illuminate\Support\Facades\Facade.php:218
C:\wamp64\www\koel\tests\TestCase.php:56
C:\wamp64\www\koel\tests\TestCase.php:25

ERRORS!
Tests: 1, Assertions: 0, Errors: 1.
```