### PR TITLE
Return 'home' view

### DIFF
--- a/resources/assets/js/components/main-wrapper/sidebar/index.vue
+++ b/resources/assets/js/components/main-wrapper/sidebar/index.vue
@@ -68,7 +68,7 @@ export default {
 
   data() {
     return {
-      currentView: 'queue',
+      currentView: 'home',
       user: userStore.state,
       showing: !isMobile.phone,
       sharedState: sharedStore.state,


### PR DESCRIPTION
I noticed that when you browse to `/` we redirect to `/#!/home` but the sidebar returns `queue` as the `currentView`.