### PR TITLE
Remove droppable scrollbar

### DIFF
--- a/resources/assets/js/components/main-wrapper/sidebar/index.vue
+++ b/resources/assets/js/components/main-wrapper/sidebar/index.vue
@@ -164,7 +164,8 @@ export default {
 
   a.droppable {
     transform: scale(1.2);
-    transition: .3s;
+    width: 213px;
+    transition: .2s;
     transform-origin: center left;
 
     color: $colorMainText;


### PR DESCRIPTION
I noticed the the `droppable` effect was very buggy in firefox which made me notice that the scaling creates a scrollbar in the bottom of the sidebar
![chrome before - queue](https://cloud.githubusercontent.com/assets/10334679/18765341/4b45911e-80e3-11e6-82e9-a5cff3a12066.gif)

I added `width` to remove it and lowered the transition to be a little faster since its now less of a transformation.