### PR TITLE
feature/sqlite-support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   SESSION_DRIVER: array
   QUEUE_DRIVER: sync
   DB_CONNECTION: sqlite
-  DB_DATABASE: :memory:
+  DB_DATABASE: ':memory:'
   APP_KEY: 16efa6c23c2e8c705826b0e66778fbe7
   JWT_SECRET: ki8jSvMf5wFrlSRBAWcGbmAzBUJfc8p8
   ADMIN_EMAIL: koel@example.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   SESSION_DRIVER: array
   QUEUE_DRIVER: sync
   DB_CONNECTION: sqlite
+  DB_DATABASE: :memory:
   APP_KEY: 16efa6c23c2e8c705826b0e66778fbe7
   JWT_SECRET: ki8jSvMf5wFrlSRBAWcGbmAzBUJfc8p8
   ADMIN_EMAIL: koel@example.com

--- a/config/database.php
+++ b/config/database.php
@@ -48,7 +48,7 @@ return [
 
         'sqlite' => [
             'driver'   => 'sqlite',
-            'database' => ':memory:',
+            'database' => env('DB_DATABASE', ':memory:'),
             'prefix'   => '',
         ],
 


### PR DESCRIPTION
This PR adds possibility to use sqlite as db driver by configuring DB_DATABASE env variable to point to database file. Defaults to in-memory db like original code.