### PR TITLE
A way to speed-up login on slow CPU

### DIFF
--- a/app/Console/Commands/InitCache.php
+++ b/app/Console/Commands/InitCache.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Application;
+use App\Models\Artist;
+use App\Models\Interaction;
+use App\Models\Playlist;
+use App\Models\User;
+use App\Models\Setting;
+use Illuminate\Console\Command;
+use Lastfm;
+use YouTube;
+
+class InitCache extends Command
+{
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'koel:init-cache';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Speed up login (requires APC cache enabled)';
+
+    /**
+     * The progress bar.
+     *
+     * @var \Symfony\Component\Console\Helper\ProgressBar
+     */
+    protected $bar;
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+
+        if (env('CACHE_DRIVER') != 'apc') {
+            $this->error('Requires APC cache driver.');
+            return;
+        }
+        $this->info('Starting to cache profiles, playlists and settings...');
+        $users = User::all();
+        $this->createProgressBar(count($users));
+        foreach ($users as $user) {
+            $playlists = Playlist::where('user_id', $user->id)->orderBy('name')->with('songs')->get()->toArray();
+
+            // We don't need full song data, just ID's
+            foreach ($playlists as &$playlist) {
+                $playlist['songs'] = array_pluck($playlist['songs'], 'id');
+            }
+
+            $response = response()->json([
+                'artists' => Artist::orderBy('name')->with('albums', with('albums.songs'))->get(),
+                'settings' => $user->is_admin ? Setting::pluck('value', 'key')->all() : [],
+                'playlists' => $playlists,
+                'interactions' => Interaction::where('user_id', $user->id)->get(),
+                'users' => $user->is_admin ? User::all() : [],
+                'currentUser' => $user,
+                'useLastfm' => Lastfm::used(),
+                'useYouTube' => YouTube::enabled(),
+                'allowDownload' => config('koel.download.allow'),
+                'cdnUrl' => app()->staticUrl(),
+                'currentVersion' => Application::VERSION,
+                'latestVersion' => $user->is_admin ? app()->getLatestVersion() : Application::VERSION,
+            ]);
+
+            apc_store($user->id.'_load', $response, 86400);
+            $this->updateProgressBar();
+        }
+        $this->finishProgressBar();
+    }
+
+    /**
+     * Create a progress bar.
+     *
+     * @param int $max Max steps
+     */
+    public function createProgressBar($max)
+    {
+        $this->bar = $this->getOutput()->createProgressBar($max + 1);
+        $this->bar->setProgress(1);
+    }
+
+    /**
+     * Update the progress bar (advance by 1 step).
+     */
+    public function updateProgressBar()
+    {
+        $this->bar->advance();
+    }
+
+    /**
+     * End the progress bar.
+     */
+    public function finishProgressBar()
+    {
+        $this->bar->finish();
+    }
+}

--- a/app/Console/Commands/InitCache.php
+++ b/app/Console/Commands/InitCache.php
@@ -54,7 +54,7 @@ class InitCache extends Command
     {
         if (env('CACHE_DRIVER') != 'apc') {
             $this->error('Requires APC cache driver.');
-            
+
             return;
         }
         $this->info('Starting to cache profiles, playlists and settings...');

--- a/app/Console/Commands/InitCache.php
+++ b/app/Console/Commands/InitCache.php
@@ -6,15 +6,14 @@ use App\Application;
 use App\Models\Artist;
 use App\Models\Interaction;
 use App\Models\Playlist;
-use App\Models\User;
 use App\Models\Setting;
+use App\Models\User;
 use Illuminate\Console\Command;
 use Lastfm;
 use YouTube;
 
 class InitCache extends Command
 {
-
     /**
      * The name and signature of the console command.
      *
@@ -53,9 +52,9 @@ class InitCache extends Command
      */
     public function handle()
     {
-
         if (env('CACHE_DRIVER') != 'apc') {
             $this->error('Requires APC cache driver.');
+            
             return;
         }
         $this->info('Starting to cache profiles, playlists and settings...');

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -16,6 +16,7 @@ class Kernel extends ConsoleKernel
         Commands\SyncMedia::class,
         Commands\Init::class,
         Commands\GenerateJWTSecret::class,
+        Commands\InitCache::class,
     ];
 
     /**

--- a/app/Http/Controllers/API/DataController.php
+++ b/app/Http/Controllers/API/DataController.php
@@ -12,36 +12,46 @@ use iTunes;
 use Lastfm;
 use YouTube;
 
-class DataController extends Controller
+class DataController extends Controller 
 {
+
     /**
      * Get a set of application data.
      *
      * @return \Illuminate\Http\JsonResponse
      */
-    public function index()
+    public function index() 
     {
-        $playlists = Playlist::byCurrentUser()->orderBy('name')->with('songs')->get()->toArray();
+        if (env('CACHE_DRIVER') == 'apc' && apc_exists(auth()->user()->id.'_load')) {
+            return apc_fetch(auth()->user()->id.'_load');
+        } else {
+            $playlists = Playlist::byCurrentUser()->orderBy('name')->with('songs')->get()->toArray();
 
-        // We don't need full song data, just ID's
-        foreach ($playlists as &$playlist) {
-            $playlist['songs'] = array_pluck($playlist['songs'], 'id');
+            // We don't need full song data, just ID's
+            foreach ($playlists as &$playlist) {
+                $playlist['songs'] = array_pluck($playlist['songs'], 'id');
+            }
+
+            $response = response()->json([
+                'artists' => Artist::orderBy('name')->with('albums', with('albums.songs'))->get(),
+                'settings' => auth()->user()->is_admin ? Setting::pluck('value', 'key')->all() : [],
+                'playlists' => $playlists,
+                'interactions' => Interaction::byCurrentUser()->get(),
+                'users' => auth()->user()->is_admin ? User::all() : [],
+                'currentUser' => auth()->user(),
+                'useLastfm' => Lastfm::used(),
+                'useYouTube' => YouTube::enabled(),
+                'useiTunes' => iTunes::used(),
+                'allowDownload' => config('koel.download.allow'),
+                'cdnUrl' => app()->staticUrl(),
+                'currentVersion' => Application::KOEL_VERSION,
+                'latestVersion' => auth()->user()->is_admin ? app()->getLatestVersion() : Application::KOEL_VERSION,
+            ]);
+
+            if (env('CACHE_DRIVER') == 'apc') {
+                apc_store(auth()->user()->id.'_load', $response, 86400);
+            }
+            return $response;
         }
-
-        return response()->json([
-            'artists' => Artist::orderBy('name')->with('albums', with('albums.songs'))->get(),
-            'settings' => auth()->user()->is_admin ? Setting::pluck('value', 'key')->all() : [],
-            'playlists' => $playlists,
-            'interactions' => Interaction::byCurrentUser()->get(),
-            'users' => auth()->user()->is_admin ? User::all() : [],
-            'currentUser' => auth()->user(),
-            'useLastfm' => Lastfm::used(),
-            'useYouTube' => YouTube::enabled(),
-            'useiTunes' => iTunes::used(),
-            'allowDownload' =>  config('koel.download.allow'),
-            'cdnUrl' => app()->staticUrl(),
-            'currentVersion' => Application::KOEL_VERSION,
-            'latestVersion' => auth()->user()->is_admin ? app()->getLatestVersion() : Application::KOEL_VERSION,
-        ]);
     }
 }

--- a/app/Http/Controllers/API/DataController.php
+++ b/app/Http/Controllers/API/DataController.php
@@ -50,7 +50,7 @@ class DataController extends Controller
             if (env('CACHE_DRIVER') == 'apc') {
                 apc_store(auth()->user()->id.'_load', $response, 86400);
             }
-            
+
             return $response;
         }
     }

--- a/app/Http/Controllers/API/DataController.php
+++ b/app/Http/Controllers/API/DataController.php
@@ -12,15 +12,14 @@ use iTunes;
 use Lastfm;
 use YouTube;
 
-class DataController extends Controller 
+class DataController extends Controller
 {
-
     /**
      * Get a set of application data.
      *
      * @return \Illuminate\Http\JsonResponse
      */
-    public function index() 
+    public function index()
     {
         if (env('CACHE_DRIVER') == 'apc' && apc_exists(auth()->user()->id.'_load')) {
             return apc_fetch(auth()->user()->id.'_load');
@@ -51,6 +50,7 @@ class DataController extends Controller
             if (env('CACHE_DRIVER') == 'apc') {
                 apc_store(auth()->user()->id.'_load', $response, 86400);
             }
+            
             return $response;
         }
     }


### PR DESCRIPTION
Hi,

Sorry for the triple post. 

I use Koel on a Raspberry 3, I have 20 000 songs, login takes around 50 seconds.
So I added a cache system that speed up the process to less than 10 seconds.

Just add ```php artisan koel:init-cache``` to your cron jobs and it'll cache everything that each user may need to login.

Works only with APC.

Cheers