### PR TITLE
Fix equalizer bug upon Koel starting 

### DIFF
--- a/resources/assets/js/components/site-footer/equalizer.vue
+++ b/resources/assets/js/components/site-footer/equalizer.vue
@@ -125,9 +125,6 @@ export default {
       prevFilter.connect(context.destination)
 
       this.$nextTick(this.createSliders)
-
-      // Now we set this value to trigger the audio processing.
-      this.selectedPresetIndex = preferences.selectedPreset
     },
 
     /**
@@ -166,6 +163,9 @@ export default {
           this.save()
         })
       })
+
+      // Now we set this value to trigger the audio processing.
+      this.selectedPresetIndex = preferences.selectedPreset
     },
 
     /**


### PR DESCRIPTION
If a preset was used in the previous session.

Now the application starts (before, it triggered an exception and failed to mount).