### PR TITLE
Use --prefer-dist to benefit from composer cache on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   - npm install -g yarn
   - yarn
   - composer self-update
-  - composer install --prefer-source --no-interaction
+  - composer install --prefer-dist --no-interaction
 
 script:
   - phpunit


### PR DESCRIPTION
* `--prefer-source` takes 117 seconds every builds.

![image](https://cloud.githubusercontent.com/assets/1130921/25319204/08ea1fd8-28d6-11e7-9d23-be682c725483.png)

* `--prefer-dist` takes only 13 seconds after cached.

![image](https://cloud.githubusercontent.com/assets/1130921/25319215/2042ffce-28d6-11e7-8d48-d1f252795e5c.png)