### PR TITLE
Add sqlite support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ APP_NAME=Koel
 #   mysql (MySQL/MariaDB - default)
 #   pgsql (PostgreSQL)
 #   sqlsrv (Microsoft SQL Server)
+#   sqlite-persistent (Local sqlite file)
 DB_CONNECTION=mysql
 DB_HOST=127.0.0.1
 DB_PORT=3306

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ Homestead.json
 db.mwb.bak
 bower_components
 /CHANGE
+koel.db
 
 ### Node ###
 # Logs

--- a/config/database.php
+++ b/config/database.php
@@ -45,6 +45,12 @@ return [
             'prefix'   => '',
         ],
 
+        'sqlite-persistent' => [
+            'driver'   => 'sqlite',
+            'database' => __DIR__.'/../'.env('DB_DATABASE', 'koel.db'),
+            'prefix'   => '',
+        ],
+
         'mysql' => [
             'driver'    => 'mysql',
             'host'      => env('DB_HOST', 'localhost'),


### PR DESCRIPTION
All the tests already seem to run on sqlite, so there (in my mind) is no reason to not provide support for it.

The only change needed was to lower the delete chunk size.