### PR TITLE
enable foreign keys for sqlite connections

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -20,7 +20,7 @@ class AppServiceProvider extends ServiceProvider
         Schema::defaultStringLength(191);
 
         // Enable on delete cascade for sqlite connections
-        if(DB::connection() instanceof \Illuminate\Database\SQLiteConnection){
+        if (DB::connection() instanceof \Illuminate\Database\SQLiteConnection) {
             DB::statement(DB::raw('PRAGMA foreign_keys = ON'));
         }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\ServiceProvider;
@@ -17,6 +18,11 @@ class AppServiceProvider extends ServiceProvider
     {
         // Fix utf8mb4-related error starting from Laravel 5.4
         Schema::defaultStringLength(191);
+
+        // Enable on delete cascade for sqlite connections
+        if(DB::connection() instanceof \Illuminate\Database\SQLiteConnection){
+            DB::statement(DB::raw('PRAGMA foreign_keys = ON'));
+        }
 
         // Add some custom validation rules
         Validator::extend('path.valid', function ($attribute, $value, $parameters, $validator) {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use DB;
+use Illuminate\Database\SQLiteConnection;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\ServiceProvider;
@@ -20,7 +21,7 @@ class AppServiceProvider extends ServiceProvider
         Schema::defaultStringLength(191);
 
         // Enable on delete cascade for sqlite connections
-        if (DB::connection() instanceof \Illuminate\Database\SQLiteConnection) {
+        if (DB::connection() instanceof SQLiteConnection) {
             DB::statement(DB::raw('PRAGMA foreign_keys = ON'));
         }
 


### PR DESCRIPTION
I know, the sqlite connection is not officially supported for production mode. But I have not limitations except for the on delete trigger. Perhaps you'd like to merge it anyway.