### PR TITLE
add support for non root installations

### DIFF
--- a/resources/assets/js/components/auth/login-form.vue
+++ b/resources/assets/js/components/auth/login-form.vue
@@ -80,7 +80,7 @@ form {
   &::before {
     content: " ";
     display: block;
-    background: url(/public/img/logo.svg) center top no-repeat;
+    background: url(../../../img/logo.svg) center top no-repeat;
     background-size: 156px;
     height: 172px;
   }

--- a/resources/assets/js/components/main-wrapper/extra/album-info.vue
+++ b/resources/assets/js/components/main-wrapper/extra/album-info.vue
@@ -80,7 +80,7 @@ export default {
     },
 
     iTunesUrl () {
-      return `${window.baseUrl}api/itunes/album/${this.album.id}&jwt-token=${ls.get('jwt-token')}`
+      return `${window.BASE_URL}api/itunes/album/${this.album.id}&jwt-token=${ls.get('jwt-token')}`
     }
   },
 

--- a/resources/assets/js/components/main-wrapper/extra/album-info.vue
+++ b/resources/assets/js/components/main-wrapper/extra/album-info.vue
@@ -80,7 +80,7 @@ export default {
     },
 
     iTunesUrl () {
-      return `/api/itunes/album/${this.album.id}&jwt-token=${ls.get('jwt-token')}`
+      return `${window.baseUrl}api/itunes/album/${this.album.id}&jwt-token=${ls.get('jwt-token')}`
     }
   },
 

--- a/resources/assets/js/components/main-wrapper/main-content/album.vue
+++ b/resources/assets/js/components/main-wrapper/main-content/album.vue
@@ -8,7 +8,7 @@
 
         <span class="meta" v-show="album.songs.length">
           by
-          <a class="artist" v-if="isNormalArtist" :href="`/#!/artist/${album.artist.id}`">{{ album.artist.name }}</a>
+          <a class="artist" v-if="isNormalArtist" :href="`#!/artist/${album.artist.id}`">{{ album.artist.name }}</a>
           <span class="nope" v-else>{{ album.artist.name }}</span>
           •
           {{ album.songs.length | pluralize('song') }}

--- a/resources/assets/js/components/main-wrapper/main-content/profile.vue
+++ b/resources/assets/js/components/main-wrapper/main-content/profile.vue
@@ -162,7 +162,7 @@ export default {
      */
     connectToLastfm () {
       window.open(
-        `/api/lastfm/connect?jwt-token=${ls.get('jwt-token')}`,
+        `${window.baseUrl}api/lastfm/connect?jwt-token=${ls.get('jwt-token')}`,
         '_blank',
         'toolbar=no,titlebar=no,location=no,width=1024,height=640'
       )

--- a/resources/assets/js/components/main-wrapper/main-content/profile.vue
+++ b/resources/assets/js/components/main-wrapper/main-content/profile.vue
@@ -162,7 +162,7 @@ export default {
      */
     connectToLastfm () {
       window.open(
-        `${window.baseUrl}api/lastfm/connect?jwt-token=${ls.get('jwt-token')}`,
+        `${window.BASE_URL}api/lastfm/connect?jwt-token=${ls.get('jwt-token')}`,
         '_blank',
         'toolbar=no,titlebar=no,location=no,width=1024,height=640'
       )

--- a/resources/assets/js/components/main-wrapper/sidebar/index.vue
+++ b/resources/assets/js/components/main-wrapper/sidebar/index.vue
@@ -5,27 +5,27 @@
 
       <ul class="menu">
         <li>
-          <a :class="['home', currentView == 'home' ? 'active' : '']" href="/#!/home">Home</a>
+          <a :class="['home', currentView == 'home' ? 'active' : '']" href="#!/home">Home</a>
         </li>
         <li>
           <a :class="['queue', currentView == 'queue' ? 'active' : '']"
-            href="/#!/queue"
+            href="#!/queue"
             @dragleave="removeDroppableState"
             @dragenter.prevent="allowDrop"
             @dragover.prevent
             @drop.stop.prevent="handleDrop">Current Queue</a>
         </li>
         <li>
-          <a :class="['songs', currentView == 'songs' ? 'active' : '']" href="/#!/songs">All Songs</a>
+          <a :class="['songs', currentView == 'songs' ? 'active' : '']" href="#!/songs">All Songs</a>
         </li>
         <li>
-          <a :class="['albums', currentView == 'albums' ? 'active' : '']" href="/#!/albums">Albums</a>
+          <a :class="['albums', currentView == 'albums' ? 'active' : '']" href="#!/albums">Albums</a>
         </li>
         <li>
-          <a :class="['artists', currentView == 'artists' ? 'active' : '']" href="/#!/artists">Artists</a>
+          <a :class="['artists', currentView == 'artists' ? 'active' : '']" href="#!/artists">Artists</a>
         </li>
         <li v-if="sharedState.useYouTube">
-          <a :class="['youtube', currentView == 'youtubePlayer' ? 'active' : '']" href="/#!/youtube">YouTube Video</a>
+          <a :class="['youtube', currentView == 'youtubePlayer' ? 'active' : '']" href="#!/youtube">YouTube Video</a>
         </li>
       </ul>
     </section>
@@ -37,10 +37,10 @@
 
       <ul class="menu">
         <li>
-          <a :class="['settings', currentView == 'settings' ? 'active' : '']" href="/#!/settings">Settings</a>
+          <a :class="['settings', currentView == 'settings' ? 'active' : '']" href="#!/settings">Settings</a>
         </li>
         <li>
-          <a :class="['users', currentView == 'users' ? 'active' : '']" href="/#!/users">Users</a>
+          <a :class="['users', currentView == 'users' ? 'active' : '']" href="#!/users">Users</a>
         </li>
       </ul>
     </section>

--- a/resources/assets/js/components/main-wrapper/sidebar/playlist-item.vue
+++ b/resources/assets/js/components/main-wrapper/sidebar/playlist-item.vue
@@ -55,7 +55,7 @@ export default {
     },
 
     playlistUrl () {
-      return this.isFavorites ? '/#!/favorites' : `/#!/playlist/${this.playlist.id}`
+      return this.isFavorites ? '#!/favorites' : `#!/playlist/${this.playlist.id}`
     }
   },
 

--- a/resources/assets/js/components/shared/album-item.vue
+++ b/resources/assets/js/components/shared/album-item.vue
@@ -7,9 +7,9 @@
     </span>
     <footer>
       <div class="info">
-        <a class="name" :href="`/#!/album/${album.id}`">{{ album.name }}</a>
+        <a class="name" :href="`#!/album/${album.id}`">{{ album.name }}</a>
         <span class="sep">by</span>
-        <a class="artist" v-if="isNormalArtist" :href="`/#!/artist/${album.artist.id}`">{{ album.artist.name }}</a>
+        <a class="artist" v-if="isNormalArtist" :href="`#!/artist/${album.artist.id}`">{{ album.artist.name }}</a>
         <span class="artist nope" v-else>{{ album.artist.name }}</span>
       </div>
       <p class="meta">

--- a/resources/assets/js/components/shared/artist-item.vue
+++ b/resources/assets/js/components/shared/artist-item.vue
@@ -7,7 +7,7 @@
     </span>
     <footer>
       <div class="info">
-        <a class="name" :href="`/#!/artist/${artist.id}`">{{ artist.name }}</a>
+        <a class="name" :href="`#!/artist/${artist.id}`">{{ artist.name }}</a>
       </div>
       <p class="meta">
         <span class="left">

--- a/resources/assets/js/components/shared/home-song-item.vue
+++ b/resources/assets/js/components/shared/home-song-item.vue
@@ -13,7 +13,7 @@
       <span v-if="showPlayCount" :style="{ width: song.playCount*100/topPlayCount+'%' }" class="play-count"/>
       {{ song.title }}
       <span class="by">
-        <a :href="`/#!/artist/${song.artist.id}`">{{ song.artist.name }}</a>
+        <a :href="`#!/artist/${song.artist.id}`">{{ song.artist.name }}</a>
         <template v-if="showPlayCount">- {{ song.playCount | pluralize('play') }}</template>
       </span>
     </span>

--- a/resources/assets/js/components/shared/sound-bar.vue
+++ b/resources/assets/js/components/shared/sound-bar.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="bars">
-    <img src="/public/img/bars.gif" alt="Sound bars" height="13" width="auto">
+    <img src="public/img/bars.gif" alt="Sound bars" height="13" width="auto">
   </div>
 </template>
 

--- a/resources/assets/js/components/shared/track-list-item.vue
+++ b/resources/assets/js/components/shared/track-list-item.vue
@@ -52,7 +52,7 @@ export default {
     },
 
     iTunesUrl () {
-      return `/api/itunes/song/${this.album.id}?q=${encodeURIComponent(this.track.title)}&jwt-token=${ls.get('jwt-token')}`
+      return `${window.baseUrl}api/itunes/song/${this.album.id}?q=${encodeURIComponent(this.track.title)}&jwt-token=${ls.get('jwt-token')}`
     }
   },
 

--- a/resources/assets/js/components/shared/track-list-item.vue
+++ b/resources/assets/js/components/shared/track-list-item.vue
@@ -52,7 +52,7 @@ export default {
     },
 
     iTunesUrl () {
-      return `${window.baseUrl}api/itunes/song/${this.album.id}?q=${encodeURIComponent(this.track.title)}&jwt-token=${ls.get('jwt-token')}`
+      return `${window.BASE_URL}api/itunes/song/${this.album.id}?q=${encodeURIComponent(this.track.title)}&jwt-token=${ls.get('jwt-token')}`
     }
   },
 

--- a/resources/assets/js/components/site-footer/index.vue
+++ b/resources/assets/js/components/site-footer/index.vue
@@ -20,8 +20,8 @@
         <div class="progress" id="progressPane">
           <h3 class="title">{{ song.title }}</h3>
           <p class="meta">
-            <a class="artist" :href="`/#!/artist/${song.artist.id}`">{{ song.artist.name }}</a> –
-            <a class="album" :href="`/#!/album/${song.album.id}`">{{ song.album.name }}</a>
+            <a class="artist" :href="`#!/artist/${song.artist.id}`">{{ song.artist.name }}</a> –
+            <a class="album" :href="`#!/album/${song.album.id}`">{{ song.album.name }}</a>
           </p>
 
           <div class="plyr">
@@ -45,7 +45,7 @@
             v-if="useEqualizer"
             @click="showEqualizer = !showEqualizer"
             :class="{ active: showEqualizer }"/>
-          <a v-else class="queue control" :class="{ active: viewingQueue }" href="/#!/queue">
+          <a v-else class="queue control" :class="{ active: viewingQueue }" href="#!/queue">
             <i class="fa fa-list-ol"></i>
           </a>
           <span class="repeat control" :class="prefs.repeatMode" @click.prevent="changeRepeatMode">

--- a/resources/assets/js/components/site-footer/index.vue
+++ b/resources/assets/js/components/site-footer/index.vue
@@ -370,7 +370,7 @@ export default {
   .album-thumb {
     flex: 0 0 $footerHeight;
     height: $footerHeight;
-    background: url(/public/img/covers/unknown-album.png);
+    background: url(../../../img/covers/unknown-album.png);
     background-size: cover;
     position: relative;
   }

--- a/resources/assets/js/components/site-header/user-badge.vue
+++ b/resources/assets/js/components/site-header/user-badge.vue
@@ -1,6 +1,6 @@
 <template>
   <span class="profile" id="userBadge">
-    <a class="view-profile control" href="/#!/profile">
+    <a class="view-profile control" href="#!/profile">
       <img class="avatar" :src="state.current.avatar" alt="Avatar"/>
       <span class="name">{{ state.current.name }}</span>
     </a>

--- a/resources/assets/js/router.js
+++ b/resources/assets/js/router.js
@@ -120,6 +120,7 @@ export default {
       path = `/#!${path}`
     }
 
+    path = path.substring(1, path.length)
     document.location.href = `${document.location.origin}${path}`
   }
 }

--- a/resources/assets/js/router.js
+++ b/resources/assets/js/router.js
@@ -121,6 +121,6 @@ export default {
     }
 
     path = path.substring(1, path.length)
-    document.location.href = `${document.location.origin}${path}`
+    document.location.href = `${document.location.origin}${document.location.pathname}${path}`
   }
 }

--- a/resources/assets/js/services/download.js
+++ b/resources/assets/js/services/download.js
@@ -71,7 +71,7 @@ export const download = {
     const sep = uri.indexOf('?') === -1 ? '?' : '&'
     const iframe = document.createElement('iframe')
     iframe.style.display = 'none'
-    iframe.setAttribute('src', `/api/download/${uri}${sep}jwt-token=${ls.get('jwt-token')}`)
+    iframe.setAttribute('src', `${window.baseUrl}api/download/${uri}${sep}jwt-token=${ls.get('jwt-token')}`)
     document.body.appendChild(iframe)
   }
 }

--- a/resources/assets/js/services/download.js
+++ b/resources/assets/js/services/download.js
@@ -71,7 +71,7 @@ export const download = {
     const sep = uri.indexOf('?') === -1 ? '?' : '&'
     const iframe = document.createElement('iframe')
     iframe.style.display = 'none'
-    iframe.setAttribute('src', `${window.baseUrl}api/download/${uri}${sep}jwt-token=${ls.get('jwt-token')}`)
+    iframe.setAttribute('src', `${window.BASE_URL}api/download/${uri}${sep}jwt-token=${ls.get('jwt-token')}`)
     document.body.appendChild(iframe)
   }
 }

--- a/resources/assets/js/services/http.js
+++ b/resources/assets/js/services/http.js
@@ -36,7 +36,7 @@ export const http = {
    * Init the service.
    */
   init () {
-    axios.defaults.baseURL = '/api'
+    axios.defaults.baseURL = `${window.baseUrl}api`
 
     // Intercept the request to make sure the token is injected into the header.
     axios.interceptors.request.use(config => {

--- a/resources/assets/js/services/http.js
+++ b/resources/assets/js/services/http.js
@@ -36,7 +36,7 @@ export const http = {
    * Init the service.
    */
   init () {
-    axios.defaults.baseURL = `${window.baseUrl}api`
+    axios.defaults.baseURL = `${window.BASE_URL}api`
 
     // Intercept the request to make sure the token is injected into the header.
     axios.interceptors.request.use(config => {

--- a/resources/assets/js/services/socket.js
+++ b/resources/assets/js/services/socket.js
@@ -14,7 +14,7 @@ export const socket = {
       }
 
       this.pusher = new Pusher(window.PUSHER_APP_KEY, {
-        authEndpoint: '/api/broadcasting/auth',
+        authEndpoint: '${window.baseUrl}api/broadcasting/auth',
         auth: {
           headers: {
             Authorization: `Bearer ${ls.get('jwt-token')}`

--- a/resources/assets/js/services/socket.js
+++ b/resources/assets/js/services/socket.js
@@ -14,7 +14,7 @@ export const socket = {
       }
 
       this.pusher = new Pusher(window.PUSHER_APP_KEY, {
-        authEndpoint: '${window.baseUrl}api/broadcasting/auth',
+        authEndpoint: '${window.BASE_URL}api/broadcasting/auth',
         auth: {
           headers: {
             Authorization: `Bearer ${ls.get('jwt-token')}`

--- a/resources/assets/js/stores/song.js
+++ b/resources/assets/js/stores/song.js
@@ -283,7 +283,7 @@ export const songStore = {
    * @return {string}
    */
   getShareableUrl (song) {
-    return `${window.location.origin}/#!/song/${song.id}`
+    return `${window.location.origin}#!/song/${song.id}`
   },
 
   /**

--- a/resources/assets/js/stores/song.js
+++ b/resources/assets/js/stores/song.js
@@ -283,7 +283,7 @@ export const songStore = {
    * @return {string}
    */
   getShareableUrl (song) {
-    return `${window.location.origin}#!/song/${song.id}`
+    return `${window.baseUrl}#!/song/${song.id}`
   },
 
   /**

--- a/resources/assets/js/stores/song.js
+++ b/resources/assets/js/stores/song.js
@@ -283,7 +283,7 @@ export const songStore = {
    * @return {string}
    */
   getShareableUrl (song) {
-    return `${window.baseUrl}#!/song/${song.id}`
+    return `${window.BASE_URL}#!/song/${song.id}`
   },
 
   /**

--- a/resources/views/client-js-vars.blade.php
+++ b/resources/views/client-js-vars.blade.php
@@ -3,7 +3,7 @@
         We actually should use a library like dotenv-webpack to load .env variables.
         Unfortunately, can't get it to work for now :(
     --}}
-    window.baseUrl = "{{ asset(null) }}";
+    window.BASE_URL = "{{ asset('') }}";
     window.PUSHER_APP_KEY = "{{ env('PUSHER_APP_KEY') }}";
     window.PUSHER_APP_CLUSTER = "{{ env('PUSHER_APP_CLUSTER') }}";
 </script>

--- a/resources/views/client-js-vars.blade.php
+++ b/resources/views/client-js-vars.blade.php
@@ -1,8 +1,9 @@
 <script>
-    {{-- 
+    {{--
         We actually should use a library like dotenv-webpack to load .env variables.
         Unfortunately, can't get it to work for now :(
     --}}
+    window.baseUrl = "{{ asset(null) }}";
     window.PUSHER_APP_KEY = "{{ env('PUSHER_APP_KEY') }}";
     window.PUSHER_APP_CLUSTER = "{{ env('PUSHER_APP_CLUSTER') }}";
 </script>

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -11,6 +11,7 @@
     <meta name="theme-color" content="#282828">
     <meta name="msapplication-navbutton-color" content="#282828">
 
+    <base href="{{ asset('') }}">
     <link rel="manifest" href="{{ App::staticUrl('public/manifest.json') }}" />
     <meta name="msapplication-config" content="{{ App::staticUrl('public/browserconfig.xml') }}" />
     <link rel="icon" type="image/x-icon" href="{{ App::staticUrl('public/img/favicon.ico') }}" />

--- a/resources/views/remote.blade.php
+++ b/resources/views/remote.blade.php
@@ -12,6 +12,7 @@
     <meta name="theme-color" content="#282828">
     <meta name="msapplication-navbutton-color" content="#282828">
 
+    <base href="{{ asset('') }}">
     <link rel="manifest" href="{{ App::staticUrl('public/manifest.json') }}" />
     <meta name="msapplication-config" content="{{ App::staticUrl('public/browserconfig.xml') }}" />
     <link rel="icon" type="image/x-icon" href="{{ App::staticUrl('public/img/favicon.ico') }}" />


### PR DESCRIPTION
this is an improvement of #671 
All absolute paths were replaced with relative ones. The base url is set by Laravel in `client-js-vars.blade.php`. In API calls the base url is used instead of the root url.
With these changes it is possible to use the koel server also in a sub folder of a web server.

These changes are working fine. I hope this can be used so other people can use this functionality. #529 