### PR TITLE
Dabase driver typo for koel:init

### DIFF
--- a/app/Console/Commands/Init.php
+++ b/app/Console/Commands/Init.php
@@ -115,7 +115,7 @@ class Init extends Command
             'Your DB driver of choice',
             [
                 'mysql' => 'MySQL/MariaDB',
-                'pqsql' => 'PostgreSQL',
+                'pgsql' => 'PostgreSQL',
                 'sqlsrv' => 'SQL Server',
                 'sqlite-e2e' => 'SQLite',
             ],


### PR DESCRIPTION
Just a small PR to fix this issue that prevents the koel:init assistant to configure a PostgreSQL driver correctly because of a small typo in `setUpDatabase()`. The value should be `pgsql` and not `pqsql`.

And thank you for koel, you do an amazing job :clap: 