### PR TITLE
Use Lastfm getSimilar api to recomendations.

### DIFF
--- a/app/Http/Controllers/API/SongController.php
+++ b/app/Http/Controllers/API/SongController.php
@@ -79,6 +79,7 @@ class SongController extends Controller
             'lyrics' => $song->lyrics,
             'album_info' => $song->album->getInfo(),
             'artist_info' => $song->artist->getInfo(),
+            'similar' => $song->getSimilar(),
             'youtube' => $song->getRelatedYouTubeVideos(),
         ]);
     }

--- a/app/Models/Song.php
+++ b/app/Models/Song.php
@@ -315,6 +315,19 @@ class Song extends Model
     }
 
     /**
+     * Get the Lastfm songs related to this song.
+     *
+     * @return array|false
+     */
+    public function getSimilar()
+    {
+        if ($this->artist->is_unknown) {
+            return false;
+        }
+        return Lastfm::getSimilar($this->title, $this->artist->name);
+    }
+
+    /**
      * Sometimes the tags extracted from getID3 are HTML entity encoded.
      * This makes sure they are always sane.
      *

--- a/resources/assets/js/components/main-wrapper/extra/index.vue
+++ b/resources/assets/js/components/main-wrapper/extra/index.vue
@@ -11,6 +11,9 @@
         <a @click.prevent="currentView = 'albumInfo'"
           class="album"
           :class="{ active: currentView === 'albumInfo' }">Album</a>
+        <a @click.prevent="currentView = 'similar'"
+          class="similar"
+          :class="{ active: currentView === 'similar' }">Similar</a>
         <a @click.prevent="currentView = 'youtube'"
           v-if="sharedState.useYouTube"
           class="youtube"
@@ -29,6 +32,11 @@
           mode="sidebar"
           ref="album-info"
           v-show="currentView === 'albumInfo'"/>
+        <similar v-if="song.similar"
+          :song="song"
+          mode="similar"
+          ref="similar"
+          v-show="currentView === 'similar'"/>
         <youtube v-if="sharedState.useYouTube"
           :song="song" :youtube="song.youtube"
           ref="youtube"
@@ -48,11 +56,12 @@ import { songInfo } from '@/services'
 import lyrics from './lyrics.vue'
 import artistInfo from './artist-info.vue'
 import albumInfo from './album-info.vue'
+import similar from './similar.vue'
 import youtube from './youtube.vue'
 
 export default {
   name: 'main-wrapper--extra--index',
-  components: { lyrics, artistInfo, albumInfo, youtube },
+  components: { lyrics, artistInfo, albumInfo, similar, youtube },
 
   data () {
     return {

--- a/resources/assets/js/components/main-wrapper/extra/similar.vue
+++ b/resources/assets/js/components/main-wrapper/extra/similar.vue
@@ -1,0 +1,34 @@
+<template>
+  <article id="similar">
+    <div class="content">
+      <section class="track-listing" v-if="song.similar.tracks.length">
+        <h1>Similar Tracks</h1>
+        <ul class="tracks">
+          <li v-for="track in song.similar.tracks">
+            {{ track.title }} - {{ track.artist }}
+          </li>
+         </ul>
+        </section>
+      <p class="none" v-if="song.id && !song.lyrics">No similar tracks found.</p>
+    </div>
+  </article>
+</template>
+
+<script>
+export default {
+  props: {
+    song: {
+      type: Object,
+      required: true
+    }
+  }
+}
+</script>
+
+<style lang="scss">
+@import "~#/partials/_vars.scss";
+@import "~#/partials/_mixins.scss";
+#similar {
+  @include artist-album-info();
+}
+</style>

--- a/resources/assets/js/services/info/song.js
+++ b/resources/assets/js/services/info/song.js
@@ -4,7 +4,7 @@ import { http, albumInfo, artistInfo } from '..'
 
 export const songInfo = {
   /**
-   * Get extra song information (lyrics, artist info, album info).
+   * Get extra song information (lyrics, artist info, album info, similar).
    *
    * @param  {Object}   song
    */
@@ -15,8 +15,9 @@ export const songInfo = {
         return
       }
 
-      http.get(`${song.id}/info`, ({ data: { artist_info, album_info, youtube, lyrics }}) => {
+      http.get(`${song.id}/info`, ({ data: { artist_info, album_info, youtube, lyrics, similar}}) => {
         song.lyrics = lyrics
+        song.similar = similar
         artist_info && artistInfo.merge(song.artist, artist_info)
         album_info && albumInfo.merge(song.album, album_info)
         song.youtube = youtube


### PR DESCRIPTION
A very early version, but I'm stuck.. 😞 

At this point, if you have lastfm configured, use the getSimilar api of lastfm to return 25 recommended songs that are added to the 'info' api url of koel.

I think this is ok.. 😉  but I need help to add the panel recommendations. I would like to do it, but I do not know much about vue..

Thank you very much, for all the development!. 😄 
