### PR TITLE
Fix AWS S3 related issues.

### DIFF
--- a/app/Http/Controllers/API/ObjectStorage/S3/SongController.php
+++ b/app/Http/Controllers/API/ObjectStorage/S3/SongController.php
@@ -40,9 +40,9 @@ class SongController extends Controller
             'album_id' => $album->id,
             'artist_id' => $artist->id,
             'title' => trim(array_get($tags, 'title', '')),
-            'length' => array_get($tags, 'duration', 0),
+            'length' => array_get($tags, 'duration', 0) ?: 0,
             'track' => (int) array_get($tags, 'track'),
-            'lyrics' => array_get($tags, 'lyrics', ''),
+            'lyrics' => array_get($tags, 'lyrics', '') ?: '',
             'mtime' => time(),
         ]);
 

--- a/app/Http/Controllers/API/ObjectStorage/S3/SongController.php
+++ b/app/Http/Controllers/API/ObjectStorage/S3/SongController.php
@@ -45,6 +45,7 @@ class SongController extends Controller
             'lyrics' => array_get($tags, 'lyrics', '') ?: '',
             'mtime' => time(),
         ]);
+        event(new LibraryChanged());
 
         return response()->json($song);
     }


### PR DESCRIPTION
I had 2 troubles when running Koel with [the official Koel-AWS package](https://github.com/koel/koel-aws)

1. MySQL Error: "Integrity constraint violation - Column 'lyrics' cannot be null" when AWS Lambda function request to Koel's Song API. (Environment: MySQL v5.5.47 & PHP v7.1)
![error log](https://d.pr/i/l7p6vZ+)
Similar to [this issue](https://stackoverflow.com/questions/43860634/laravel-5-4-upgrade-integrity-constraint-violation-column-cannot-be-null). 

2. After storing a new songs, the song, album and artist didn't show up in Koel UI, because media cache remains.