### PR TITLE
Fix error with cover file

### DIFF
--- a/app/Services/FileSynchronizer.php
+++ b/app/Services/FileSynchronizer.php
@@ -303,12 +303,21 @@ class FileSynchronizer
             $cover = $matches ? $matches[0] : null;
 
             // Even if a file is found, make sure it's a real image.
-            if ($cover && !exif_imagetype($cover)) {
+            if ($cover && !$this->isImage($cover)) {
                 $cover = null;
             }
 
             return $cover;
         });
+    }
+
+    private function isImage(string $path): bool
+    {
+        try {
+            return !!exif_imagetype($path);
+        } catch (Exception $e) {
+            return false;
+        }
     }
 
     /**

--- a/app/Services/FileSynchronizer.php
+++ b/app/Services/FileSynchronizer.php
@@ -314,7 +314,7 @@ class FileSynchronizer
     private function isImage(string $path): bool
     {
         try {
-            return !!exif_imagetype($path);
+            return (bool) exif_imagetype($path);
         } catch (Exception $e) {
             return false;
         }


### PR DESCRIPTION
`exif_imagetype()` can fail if the image is too small, breaking the whole scan. This fixes the issue.