### PR TITLE
Updated app.php default encryption key

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -81,7 +81,7 @@ return [
     |
     */
 
-    'key' => env('APP_KEY', 'SomeRandomString'),
+    'key' => env('APP_KEY', 'SomeRandomStringWith32Characters'),
 
     'cipher' => 'AES-256-CBC',
 


### PR DESCRIPTION
For the sake of testing, it is easier to have the key fit the required 32 character limit for AES-256-CBC. If the default 'SomeRandomString' placeholder is used, an invalid key length error is returned.