### PR TITLE
Non interactive koel:init

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
+APP_NAME=Koel
+
 # Database connection name, which corresponds to the database driver.
 # Possible values are:
 #   mysql (MySQL/MariaDB - default)
@@ -15,6 +17,17 @@ APP_KEY=
 
 # Another random 32-char string. You can leave this empty if use php artisan koel:init.
 JWT_SECRET=
+
+# Credentials and other info to be used when Koel is installed in non-interactive mode
+# (php artisan koel:init --no-interaction)
+# By default (interactive mode), Koel will still prompt for these information during installation,
+# but provide the values here as the defaults (except ADMIN_PASSWORD, for security reason).
+ADMIN_NAME="Koel Admin"
+ADMIN_EMAIL=admin@koel.com
+ADMIN_PASSWORD=SoSecureMuchWow
+# The ABSOLUTE path to your media. This value can always be changed later via the web interface.
+MEDIA_PATH=
+
 
 # By default, Koel ignores dot files and folders. This greatly improves performance if your media
 # root have folders like .git or .cache. If by any chance your media files are under a dot folder,

--- a/app/Console/Commands/InitCommand.php
+++ b/app/Console/Commands/InitCommand.php
@@ -174,30 +174,28 @@ class InitCommand extends Command
 
             if (is_dir($path) && is_readable($path)) {
                 Setting::set('media_path', $path);
+            } else {
+                $this->error('The path '.$path.' does not exist or not readable. Skipping.');
+            }
+
+            return;
+        }
+
+        $this->info('The absolute path to your media directory. If this is skipped (left blank) now, you can set it later via the web interface.');
+
+        while (true) {
+            $path = $this->ask('Media path', false);
+
+            if ($path === false) {
                 return;
             }
 
-            $this->error('The path '.$path.' does not exist or not readable. Skipping.');
-            return;
-
-        } else {
-
-            $this->info('The absolute path to your media directory. If this is skipped (left blank) now, you can set it later via the web interface.');
-
-            while (true) {
-                $path = $this->ask('Media path', false);
-
-                if ($path === false) {
-                    return;
-                }
-
-                if (is_dir($path) && is_readable($path)) {
-                    Setting::set('media_path', $path);
-                    return;
-                }
-
-                $this->error('The path does not exist or not readable. Try again.');
+            if (is_dir($path) && is_readable($path)) {
+                Setting::set('media_path', $path);
+                return;
             }
+
+            $this->error('The path does not exist or not readable. Try again.');
         }
     }
 

--- a/app/Console/Commands/InitCommand.php
+++ b/app/Console/Commands/InitCommand.php
@@ -50,7 +50,7 @@ class InitCommand extends Command
         $this->info('📙  '.config('koel.misc.docs_url').PHP_EOL);
 
         if ($this->inNoInteractionMode()) {
-            $this->info('Running in --no-interaction mode');
+            $this->info('Running in no-interaction mode');
         }
 
         $this->maybeGenerateAppKey();
@@ -134,11 +134,11 @@ class InitCommand extends Command
     {
         $this->info("Let's create the admin account.");
         if ($this->inNoInteractionMode()) {
-            $name     = config('koel.admin.name');
-            $email    = config('koel.admin.email');
+            $name = config('koel.admin.name');
+            $email = config('koel.admin.email');
             $password = config('koel.admin.password');
         } else {
-            $name  = $this->ask('Your name');
+            $name = $this->ask('Your name');
             $email = $this->ask('Your email address');
             $passwordConfirmed = false;
             $password = null;
@@ -178,6 +178,7 @@ class InitCommand extends Command
             }
 
             $this->error('The path '.$path.' does not exist or not readable. Skipping.');
+            return;
 
         } else {
 

--- a/app/Console/Commands/InitCommand.php
+++ b/app/Console/Commands/InitCommand.php
@@ -124,20 +124,38 @@ class InitCommand extends Command
     private function setUpAdminAccount(): void
     {
         $this->info("Let's create the admin account.");
-        $name = $this->ask('Your name');
-        $email = $this->ask('Your email address');
-        $passwordConfirmed = false;
-        $password = null;
 
-        while (!$passwordConfirmed) {
-            $password = $this->secret('Your desired password');
-            $confirmation = $this->secret('Again, just to make sure');
+        $name = config('koel.admin.name');
+        if (!$name) {
+            $name = $this->ask('Your name');
+        } else {
+            $this->comment('Admin name exists => '.$name);
+        }
 
-            if ($confirmation !== $password) {
-                $this->error('That doesn\'t match. Let\'s try again.');
-            } else {
-                $passwordConfirmed = true;
+        $email = config('koel.admin.email');
+        if (!$email) {
+            $email = $this->ask('Your email address');
+        } else {
+            $this->comment('Admin email exists => '.$email);
+        }
+
+        $password = config('koel.admin.password');
+        if (!$password) {
+            $passwordConfirmed = false;
+            $password = null;
+
+            while (!$passwordConfirmed) {
+                $password = $this->secret('Your desired password');
+                $confirmation = $this->secret('Again, just to make sure');
+
+                if ($confirmation !== $password) {
+                    $this->error('That doesn\'t match. Let\'s try again.');
+                } else {
+                    $passwordConfirmed = true;
+                }
             }
+        } else {
+            $this->comment('Admin password exists => '.str_repeat("*", strlen($password)));
         }
 
         User::create([

--- a/app/Console/Commands/InitCommand.php
+++ b/app/Console/Commands/InitCommand.php
@@ -174,20 +174,31 @@ class InitCommand extends Command
 
         $this->info('The absolute path to your media directory. If this is skipped (left blank) now, you can set it later via the web interface.');
 
-        while (true) {
-            $path = $this->ask('Media path', false);
+        $path = config('koel.media_path');
+        if (!$path) {
+            while (true) {
+                $path = $this->ask('Media Path', false);
 
-            if ($path === false) {
-                return;
+                if ($path === false) {
+                    return;
+                }
+
+                if (is_dir($path) && is_readable($path)) {
+                    Setting::set('media_path', $path);
+                    return;
+                }
+
+                $this->error('The path does not exist or not readable. Try again.');
             }
+        } else {
+            $this->comment('Media Path exists => '.$path);
 
             if (is_dir($path) && is_readable($path)) {
-                Setting::set('media_path', $path);
-
-                return;
+              Setting::set('media_path', $path);
+              return;
             }
 
-            $this->error('The path does not exist or not readable. Try again.');
+            $this->error('The path '.$path.' does not exist or not readable. Skipping.');
         }
     }
 

--- a/app/Repositories/AbstractRepository.php
+++ b/app/Repositories/AbstractRepository.php
@@ -2,6 +2,7 @@
 
 namespace App\Repositories;
 
+use Exception;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
@@ -10,14 +11,21 @@ abstract class AbstractRepository implements RepositoryInterface
 {
     /** @var Model */
     protected $model;
+    
+    /** @var Guard */
     protected $auth;
 
     abstract public function getModelClass(): string;
 
-    public function __construct(Guard $auth)
+    public function __construct()
     {
         $this->model = app($this->getModelClass());
-        $this->auth = $auth;
+
+        // This instantiation may fail during a console command if e.g. APP_KEY is empty,
+        // rendering the whole installation failing.
+        try {
+            $this->auth = app(Guard::class);
+        } catch (Exception $e) {}
     }
 
     public function getOneById($id): ?Model

--- a/app/Repositories/SongRepository.php
+++ b/app/Repositories/SongRepository.php
@@ -10,9 +10,9 @@ class SongRepository extends AbstractRepository
 {
     private $helperService;
 
-    public function __construct(Guard $auth, HelperService $helperService)
+    public function __construct(HelperService $helperService)
     {
-        parent::__construct($auth);
+        parent::__construct();
         $this->helperService = $helperService;
     }
 

--- a/app/Services/MediaMetadataService.php
+++ b/app/Services/MediaMetadataService.php
@@ -5,13 +5,13 @@ namespace App\Services;
 use App\Models\Album;
 use App\Models\Artist;
 use Exception;
-use Illuminate\Log\Logger;
+use Psr\Log\LoggerInterface;
 
 class MediaMetadataService
 {
     private $logger;
 
-    public function __construct(Logger $logger)
+    public function __construct(LoggerInterface $logger)
     {
         $this->logger = $logger;
     }

--- a/app/Services/MediaSyncService.php
+++ b/app/Services/MediaSyncService.php
@@ -14,7 +14,7 @@ use App\Repositories\ArtistRepository;
 use App\Repositories\SettingRepository;
 use App\Repositories\SongRepository;
 use Exception;
-use Illuminate\Log\Logger;
+use Psr\Log\LoggerInterface;
 use SplFileInfo;
 use Symfony\Component\Finder\Finder;
 
@@ -58,7 +58,7 @@ class MediaSyncService
         HelperService $helperService,
         FileSynchronizer $fileSynchronizer,
         Finder $finder,
-        Logger $logger
+        LoggerInterface $logger
     ) {
         $this->mediaMetadataService = $mediaMetadataService;
         $this->songRepository = $songRepository;

--- a/config/koel.php
+++ b/config/koel.php
@@ -26,6 +26,8 @@ return [
     |
     */
 
+    'media_path' => env('APP_MEDIA_PATH', '/media'),
+
     'sync' => [
         'timeout' => env('APP_MAX_SCAN_TIME', 600),
     ],

--- a/config/koel.php
+++ b/config/koel.php
@@ -17,6 +17,8 @@ return [
         'password' => env('ADMIN_PASSWORD'),
     ],
 
+    'media_path' => env('MEDIA_PATH'),
+
     /*
     |--------------------------------------------------------------------------
     | Sync Options
@@ -25,8 +27,6 @@ return [
     | A timeout is set when using the browser to scan the folder path
     |
     */
-
-    'media_path' => env('APP_MEDIA_PATH', '/media'),
 
     'sync' => [
         'timeout' => env('APP_MAX_SCAN_TIME', 600),

--- a/tests/Integration/Repositories/SongRepositoryTest.php
+++ b/tests/Integration/Repositories/SongRepositoryTest.php
@@ -5,9 +5,6 @@ namespace Tests\Integration\Repositories;
 use App\Models\Song;
 use App\Repositories\SongRepository;
 use App\Services\HelperService;
-use Illuminate\Contracts\Auth\Guard;
-use Mockery;
-use Mockery\MockInterface;
 use Tests\TestCase;
 
 class SongRepositoryTest extends TestCase
@@ -18,11 +15,6 @@ class SongRepositoryTest extends TestCase
     private $helperService;
 
     /**
-     * @var Guard|MockInterface
-     */
-    private $auth;
-
-    /**
      * @var SongRepository
      */
     private $songRepository;
@@ -30,9 +22,8 @@ class SongRepositoryTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->auth = Mockery::mock(Guard::class);
         $this->helperService = new HelperService();
-        $this->songRepository = new SongRepository($this->auth, $this->helperService);
+        $this->songRepository = new SongRepository($this->helperService);
     }
 
     public function testGetOneByPath(): void


### PR DESCRIPTION
As per https://github.com/phanan/koel/commit/e1b68cc53ff078429a968cb360ea250c1bc1b589#diff-ac5db72ed5e3c5612246e80cb231cacf (Dec 3, 2017), the admin account is NOT set in the `.env` file and created during initial database seeding anymore, therefore it's required to run:

    $ php artisan koel:init

In **interactive mode** to configure koel, such process can be automatized with [expect](https://github.com/binhex/arch-koel/blob/938e4ce2646c180b5ea069f589487be2675eb24f/config/nobody/koel/init.exp) but IMHO it could be better if it uses environment variables when available.

This PR re enable:

- ADMIN_EMAIL=admin@example.com
- ADMIN_NAME=admin
- ADMIN_PASSWORD=admin

And add:

- APP_MEDIA_PATH=/music

To be able to run `$ php artisan koel:init` in **non interactive mode**