### PR TITLE
Make it easier to contribute to koel by having an online IDE

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -1,0 +1,3 @@
+FROM gitpod/workspace-mysql:latest
+
+ENV APACHE_DOCROOT_IN_REPO=""

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -22,6 +22,11 @@ tasks:
         sed -i "/FORCE_HTTPS=/c FORCE_HTTPS=true" .env;
         sed -i "/MEDIA_PATH=/c MEDIA_PATH=/workspace/media" .env;
         mkdir -p /workspace/media;
+        (cd /workspace/media;
+            wget http://www.hochmuth.com/mp3/Haydn_Cello_Concerto_D-1.mp3;
+            wget http://www.hochmuth.com/mp3/Tchaikovsky_Rococo_Var_orch.mp3;
+            wget http://www.hochmuth.com/mp3/Vivaldi_Sonata_eminor_.mp3;
+        );
         source .env;
         mysql -e "CREATE DATABASE IF NOT EXISTS $DB_DATABASE";
         mysql -e "CREATE USER '$DB_USERNAME'@'localhost' IDENTIFIED BY '$DB_PASSWORD';";

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,33 @@
+image:
+  file: .gitpod.dockerfile
+ports:
+  - port: 8001
+    onOpen: open-preview
+  - port: 3306
+    onOpen: ignore
+tasks:
+  - name: Apache
+    command: >
+        touch /var/log/apache2/error.log;
+        touch /var/log/apache2/access.log;
+        multitail /var/log/apache2/error.log -I /var/log/apache2/access.log
+  - name: koel
+    init: >
+        composer install
+    command: >
+        cp .env.example .env;
+        WORKSPACE_URL=$(gp url 8001 | sed -E s/\\/$//);
+        sed -i "/APP_URL=/c APP_URL=$WORKSPACE_URL" .env;
+        sed -i "/CDN_URL=/c CDN_URL=$WORKSPACE_URL" .env;
+        sed -i "/FORCE_HTTPS=/c FORCE_HTTPS=true" .env;
+        sed -i "/MEDIA_PATH=/c MEDIA_PATH=/workspace/media" .env;
+        mkdir -p /workspace/media;
+        source .env;
+        mysql -e "CREATE DATABASE IF NOT EXISTS $DB_DATABASE";
+        mysql -e "CREATE USER '$DB_USERNAME'@'localhost' IDENTIFIED BY '$DB_PASSWORD';";
+        mysql -e "GRANT ALL PRIVILEGES ON * . * TO '$DB_USERNAME'@'localhost';";
+        mysqladmin reload;
+        php artisan koel:init --no-interaction;
+        php artisan koel:sync;
+        php artisan key:generate;
+        apachectl start;

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ For system requirements, installation/upgrade guides, troubleshooting etc., head
 
 All contributions, big or small, are warmheartedly welcome! Please note, however, that if you want to work on a new feature, first open an issue to make sure it's something desired – doing this will greatly save time for all of us.
 
+A quick and easy way to start hacking on koel is to open and run this repo in Gitpod, an online IDE with full Laravel support.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/phanan/koel)
+
 ## Backers
 
 Support us with a monthly donation and help us continue our activities. [[Become a backer](https://opencollective.com/koel#backer)]


### PR DESCRIPTION
Hi There! hi @phanan!

I wanted to try koel but setting up may dev environment took painfully long. All that tinkering...

So I thought we can make that easier for everybody by having an online IDE ([gitpod.io](https://www.gitpod.io))) where everything is already configured, so that one can start running and hacking koel with just one click. 

If you click on the following link....
https://gitpod.io/#https://github.com/meysholdt/koel

1. a new docker-based workspace will launch. It's built from the `Dockerfile` in this PR
2. A `git clone` will fetch the koel source code. You may need to GitHub-OAuth-Login here.
3. the `.env.example` script is copied to `.env`
4. int the workspace, MySQL is started and a user+database based on the `.env` is created.
5. `php artisan koel:init` runs to let the user create a new login
6. an apache web server starts
7. koel opens in a preview in the IDE

What you see then looks like this:

![image](https://user-images.githubusercontent.com/239422/57939229-27532c80-78ca-11e9-913a-56e4d3519913.png)

Disclosure: I work on Gitpod.

Let me know what you think. I hope you find this useful. I personally think this can make it significantly easier to contribute to koel. 

There is, however, one problem I ran into. koel seems to have trouble with being behind a https-proxy. This was already reported in #725. This issue bites us when using Gitpod, because you open koel in your browser, your requests go trough a https-proxy (operated by Gitpod) to the koel-instance from your workspace. Unfortunately, koel often sends `http` requests, even though it's served via `https`. I'm happy to help out a little, but I'm not enough familiar with koel to do this on my own. 

I noticed that `composer install` and `yarn install` take several minutes to run. If you configure the [Gitpod App](https://github.com/apps/gitpod-io) on this repo, Gitpod can run them on git-push on branches and PRs. So when you open a workspace, `composer install` and `yarn install` will already have finished and you don't need to wait for them.










