### PR TITLE
Fix downloading songs from favourites playlist

### DIFF
--- a/app/Repositories/InteractionRepository.php
+++ b/app/Repositories/InteractionRepository.php
@@ -24,7 +24,7 @@ class InteractionRepository extends AbstractRepository
     {
         return $this->model->where([
             'user_id' => $user->id,
-            'like' => true,
+            'liked' => true,
         ])
             ->with('song')
             ->get()

--- a/app/Services/DownloadService.php
+++ b/app/Services/DownloadService.php
@@ -7,7 +7,7 @@ use App\Models\Artist;
 use App\Models\Playlist;
 use App\Models\Song;
 use App\Models\SongZipArchive;
-use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Collection;
 use InvalidArgumentException;
 
 class DownloadService


### PR DESCRIPTION
The column name is `liked` instead of `like` and there was a different `Collection` class being passed to the function. Fixes #746 (for me at least).