### PR TITLE
New transcodes codecs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,7 +95,7 @@ OUTPUT_BIT_RATE=128
 
 # what format you would like to transcode things to, can only be one of the following:
 # libopus, libvorbis, libmp3lame, aac, defaults to mp3 if not set.
-# FFMPEG_CODEC=mp3
+# FFMPEG_CODEC=libmp3lame
 
 # Whether to allow song downloading.
 # Note that if you're downloading more than one song, Koel will zip them up

--- a/.env.example
+++ b/.env.example
@@ -93,6 +93,10 @@ FFMPEG_PATH=/usr/local/bin/ffmpeg
 # but slower streaming and more bandwidth.
 OUTPUT_BIT_RATE=128
 
+# what format you would like to transcode things to, can only be one of the following:
+# libopus, libvorbis, libmp3lame, aac, defaults to mp3 if not set.
+# FFMPEG_CODEC=mp3
+
 # Whether to allow song downloading.
 # Note that if you're downloading more than one song, Koel will zip them up
 # using PHP's ZipArchive. So if the module isn't available in the current

--- a/app/Services/Streamers/TranscodingStreamer.php
+++ b/app/Services/Streamers/TranscodingStreamer.php
@@ -24,7 +24,24 @@ class TranscodingStreamer extends Streamer implements TranscodingStreamerInterfa
     public function stream(): void
     {
         $ffmpeg = config('koel.streaming.ffmpeg_path');
+	$codec = config('koel.streaming.ffmpeg_codec');
         abort_unless(is_executable($ffmpeg), 500, 'Transcoding requires valid ffmpeg settings.');
+
+	//used the chart on https://en.wikipedia.org/wiki/HTML5_audio#Supported_audio_coding_formats to match up formats to container types.
+	$container = null;
+	switch($codec)
+	{
+	   case 'libopus':
+	   case 'libvorbis':
+	      $container = 'ogg';
+	      break;
+	   case 'libmp3lame':
+	      $container = 'mp3';
+	      break;
+	   case 'aac':
+	      $container = 'adts';
+	      break;
+	}
 
         $bitRate = filter_var($this->bitRate, FILTER_SANITIZE_NUMBER_INT);
 
@@ -35,8 +52,9 @@ class TranscodingStreamer extends Streamer implements TranscodingStreamerInterfa
             '-i '.escapeshellarg($this->song->path),
             '-map 0:0',
             '-v 0',
-            "-ab {$bitRate}k",
-            '-f mp3',
+	    "-b:a {$bitRate}k",
+	    "-c:a {$codec}",
+            "-f {$container}",
             '-',
         ];
 

--- a/config/koel.php
+++ b/config/koel.php
@@ -47,6 +47,7 @@ return [
         'bitrate' => env('OUTPUT_BIT_RATE', 128),
         'method' => env('STREAMING_METHOD'),
         'ffmpeg_path' => env('FFMPEG_PATH'),
+	'ffmpeg_codec' => env('FFMPEG_CODEC', 'libmp3lame'),
     ],
 
     /*


### PR DESCRIPTION
This adds the ability to choose what codec you would like your FLAC file transcoded to for streaming. only supports the officially support html5 audio codecs.