### PR TITLE
Use the 2.0 branch of getID3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "require": {
     "php": ">=7.1.3",
     "laravel/framework": "5.8.*",
-    "james-heinrich/getid3": "^2.0-dev",
+    "james-heinrich/getid3": "^2.0.0-dev",
     "guzzlehttp/guzzle": "^6.1",
     "tymon/jwt-auth": "^0.5.6",
     "aws/aws-sdk-php-laravel": "^3.1",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "require": {
     "php": ">=7.1.3",
     "laravel/framework": "5.8.*",
-    "james-heinrich/getid3": "^2.0",
+    "james-heinrich/getid3": "^2.0-dev",
     "guzzlehttp/guzzle": "^6.1",
     "tymon/jwt-auth": "^0.5.6",
     "aws/aws-sdk-php-laravel": "^3.1",


### PR DESCRIPTION
This PR updates getID3 to use the latest 2.0 branch instead of the `v2.0.0-beta1` release which contains a fatal error when syncing.

The branch name came from:
https://github.com/JamesHeinrich/getID3/tree/2.0#installation

Fixes #1078