### PR TITLE
the absolute publicPath breaks a koel-sub directory installation

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -8,7 +8,7 @@ mix.webpackConfig({
   plugins,
   output: {
     chunkFilename: mix.config.inProduction ? 'js/[name].[chunkhash].js' : 'js/[name].js',
-    publicPath: '/public/'
+    publicPath: 'public/'
   }
 })
 


### PR DESCRIPTION
In a sub directory installation `https://mydomain/koel/` the asset-path ist absolute, so the resources cannot be loaded.

![koel-assets-broken](https://user-images.githubusercontent.com/8209685/71887434-5e6a9c80-313e-11ea-961d-3167f95e558b.png)

After removing the first slash in the webpack-config of the public-path and recompilation the assets are loading great now.
