### PR TITLE
Vue highlighting added for Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -36,3 +36,6 @@ tasks:
         php artisan koel:sync;
         php artisan key:generate;
         apachectl start;
+vscode:
+  extensions:
+    - octref.vetur@0.23.0:TEzauMObB6f3i2JqlvrOpA==


### PR DESCRIPTION
This PR adds vetur as an extension in Gitpod's VS code

"Vetur provides syntax highlighting, snippets, Emmet support, linting/error checking, auto-formatting, and auto-complete for Vue files."

Atm the vue files look like this on Gitpod:

<img width="774" alt="Screen Shot 2020-04-02 at 3 38 20 AM" src="https://user-images.githubusercontent.com/3472889/78233759-7595fd80-7493-11ea-952e-cc297ffbef71.png">

After this change:

<img width="766" alt="Screen Shot 2020-04-02 at 3 40 58 AM" src="https://user-images.githubusercontent.com/3472889/78234031-cdccff80-7493-11ea-9ac0-518126eee212.png">
