### PR TITLE
feat(build): upgrade actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/unit-backend-mysql.yml
+++ b/.github/workflows/unit-backend-mysql.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Run tests
         run: composer coverage
       - name: Upload logs if broken
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: logs

--- a/.github/workflows/unit-backend-pgsql.yml
+++ b/.github/workflows/unit-backend-pgsql.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Run tests
         run: composer coverage
       - name: Upload logs if broken
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: logs

--- a/.github/workflows/unit-backend.yml
+++ b/.github/workflows/unit-backend.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Run tests
         run: composer coverage
       - name: Upload logs if broken
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: logs


### PR DESCRIPTION
Upgrading `actions/upload-artifact` to v4 because GitHub just dropped support for v1 and v2 of the action:

![image](https://github.com/user-attachments/assets/de1472f9-6f0e-4f4f-85de-006b6f54f1b8)
