### PR TITLE
feat: lazy load the sidesheet content

### DIFF
--- a/resources/assets/js/components/album/AlbumInfo.vue
+++ b/resources/assets/js/components/album/AlbumInfo.vue
@@ -6,7 +6,9 @@
       <AlbumThumbnail :entity="album" class="group" />
     </template>
 
-    <template v-if="info">
+    <ParagraphSkeleton v-if="loading" />
+
+    <template v-if="!loading && info">
       <template v-if="info.wiki">
         <ExpandableContentBlock v-if="mode === 'aside'">
           <div v-html="info.wiki.full" />
@@ -24,7 +26,7 @@
       />
     </template>
 
-    <template v-if="info" #footer>
+    <template v-if="!loading && info" #footer>
       Data &copy;
       <a :href="info.url" rel="noopener" target="_blank">Last.fm</a>
     </template>
@@ -40,6 +42,7 @@ import { defineAsyncComponent } from '@/utils/helpers'
 import AlbumThumbnail from '@/components/ui/album-artist/AlbumOrArtistThumbnail.vue'
 import AlbumArtistInfo from '@/components/ui/album-artist/AlbumOrArtistInfo.vue'
 import ExpandableContentBlock from '@/components/ui/album-artist/ExpandableContentBlock.vue'
+import ParagraphSkeleton from '@/components/ui/skeletons/ParagraphSkeleton.vue'
 
 const props = withDefaults(defineProps<{ album: Album, mode?: MediaInfoDisplayMode }>(), { mode: 'aside' })
 
@@ -49,13 +52,16 @@ const { album, mode } = toRefs(props)
 
 const { useLastfm, useSpotify } = useThirdPartyServices()
 
+const loading = ref(false)
 const info = ref<AlbumInfo | null>(null)
 
 watch(album, async () => {
   info.value = null
 
   if (useLastfm.value || useSpotify.value) {
+    loading.value = true
     info.value = await mediaInfoService.fetchForAlbum(album.value)
+    loading.value = false
   }
 }, { immediate: true, deep: true })
 </script>

--- a/resources/assets/js/components/artist/ArtistInfo.vue
+++ b/resources/assets/js/components/artist/ArtistInfo.vue
@@ -6,15 +6,19 @@
       <ArtistThumbnail :entity="artist" class="group" />
     </template>
 
-    <template v-if="info?.bio">
-      <ExpandableContentBlock v-if="mode === 'aside'">
-        <div v-html="info.bio.full" />
-      </ExpandableContentBlock>
+    <ParagraphSkeleton v-if="loading" />
 
-      <div v-else v-html="info.bio.full" />
+    <template v-else>
+      <template v-if="info?.bio">
+        <ExpandableContentBlock v-if="mode === 'aside'">
+          <div v-html="info.bio.full" />
+        </ExpandableContentBlock>
+
+        <div v-else v-html="info.bio.full" />
+      </template>
     </template>
 
-    <template v-if="info" #footer>
+    <template v-if="info && !loading" #footer>
       Data &copy;
       <a :href="info.url" rel="openener" target="_blank">Last.fm</a>
     </template>
@@ -29,19 +33,23 @@ import { useThirdPartyServices } from '@/composables/useThirdPartyServices'
 import ArtistThumbnail from '@/components/ui/album-artist/AlbumOrArtistThumbnail.vue'
 import AlbumArtistInfo from '@/components/ui/album-artist/AlbumOrArtistInfo.vue'
 import ExpandableContentBlock from '@/components/ui/album-artist/ExpandableContentBlock.vue'
+import ParagraphSkeleton from '@/components/ui/skeletons/ParagraphSkeleton.vue'
 
 const props = withDefaults(defineProps<{ artist: Artist, mode?: MediaInfoDisplayMode }>(), { mode: 'aside' })
 const { artist, mode } = toRefs(props)
 
 const { useLastfm, useSpotify } = useThirdPartyServices()
 
+const loading = ref(false)
 const info = ref<ArtistInfo | null>(null)
 
 watch(artist, async () => {
   info.value = null
 
   if (useLastfm.value || useSpotify.value) {
+    loading.value = true
     info.value = await mediaInfoService.fetchForArtist(artist.value)
+    loading.value = false
   }
 }, { immediate: true })
 </script>

--- a/resources/assets/js/components/layout/main-wrapper/side-sheet/SideSheet.vue
+++ b/resources/assets/js/components/layout/main-wrapper/side-sheet/SideSheet.vue
@@ -3,7 +3,7 @@
     :class="{ 'showing-pane': activeTab }"
     class="fixed sm:relative top-0 w-screen md:w-auto flex flex-col md:flex-row-reverse z-[2] text-k-text-secondary"
   >
-    <div
+    <header
       class="controls flex md:flex-col justify-between items-center md:w-[64px] md:py-6 tw:px-0
       bg-black/5 md:border-l border-solid md:border-l-white/5 md:border-b-0 md:shadow-none
       z-[2] w-screen flex-row border-b border-b-white/5 border-l-0 shadow-xl
@@ -21,52 +21,51 @@
         <LogoutButton />
         <ProfileAvatar @click="onProfileLinkClick" />
       </div>
-    </div>
+    </header>
 
-    <div v-if="songPlaying" v-show="activeTab" class="panes py-8 px-6 overflow-auto bg-k-bg-secondary">
-      <div
-        v-show="activeTab === 'Lyrics'"
+    <main v-if="songPlaying" v-show="activeTab" class="panes py-8 px-6 overflow-auto bg-k-bg-secondary">
+      <SideSheetPanelLazyWrapper
         id="extraPanelLyrics"
+        :active="activeTab === 'Lyrics'"
+        :should-mount="shouldMountTab('Lyrics')"
         aria-labelledby="extraTabLyrics"
-        role="tabpanel"
-        tabindex="0"
+        data-testid="side-sheet-lyrics"
       >
         <LyricsPane v-if="playable" :song="playable" />
-      </div>
+      </SideSheetPanelLazyWrapper>
 
-      <div
-        v-show="activeTab === 'Artist'"
+      <SideSheetPanelLazyWrapper
         id="extraPanelArtist"
+        :active="activeTab === 'Artist'"
+        :should-mount="activatedTabs.includes('Artist')"
+        data-testid="side-sheet-artist"
         aria-labelledby="extraTabArtist"
-        role="tabpanel"
-        tabindex="0"
       >
-        <ArtistInfo v-if="artist" :artist="artist" mode="aside" />
+        <ArtistInfo v-if="artist && !loadingArtist" :artist="artist" mode="aside" />
         <SideSheetArtistAlbumInfoSkeleton v-else />
-      </div>
+      </SideSheetPanelLazyWrapper>
 
-      <div
-        v-show="activeTab === 'Album'"
+      <SideSheetPanelLazyWrapper
         id="extraPanelAlbum"
+        :active="activeTab === 'Album'"
+        :should-mount="activatedTabs.includes('Album')"
+        data-testid="side-sheet-album"
         aria-labelledby="extraTabAlbum"
-        role="tabpanel"
-        tabindex="0"
       >
-        <AlbumInfo v-if="album" :album="album" mode="aside" />
+        <AlbumInfo v-if="album && !loadingAlbum" :album="album" mode="aside" />
         <SideSheetArtistAlbumInfoSkeleton v-else />
-      </div>
+      </SideSheetPanelLazyWrapper>
 
-      <div
-        v-show="activeTab === 'YouTube'"
+      <SideSheetPanelLazyWrapper
         id="extraPanelYouTube"
+        :active="activeTab === 'YouTube'"
+        :should-mount="activatedTabs.includes('YouTube')"
         aria-labelledby="extraTabYouTube"
         data-testid="side-sheet-youtube"
-        role="tabpanel"
-        tabindex="0"
       >
         <YouTubeVideoList v-if="shouldShowYouTubeTab && playable" :song="playable" />
-      </div>
-    </div>
+      </SideSheetPanelLazyWrapper>
+    </main>
   </aside>
 </template>
 
@@ -78,7 +77,6 @@ import { computed, onMounted, ref, watch } from 'vue'
 import { albumStore } from '@/stores/albumStore'
 import { artistStore } from '@/stores/artistStore'
 import { preferenceStore } from '@/stores/preferenceStore'
-import { useErrorHandler } from '@/composables/useErrorHandler'
 import { useThirdPartyServices } from '@/composables/useThirdPartyServices'
 import { eventBus } from '@/utils/eventBus'
 import { isSong } from '@/utils/typeGuards'
@@ -89,35 +87,58 @@ import ProfileAvatar from '@/components/ui/ProfileAvatar.vue'
 import AboutKoelButton from '@/components/layout/main-wrapper/side-sheet/AboutKoelButton.vue'
 import LogoutButton from '@/components/layout/main-wrapper/side-sheet/LogoutButton.vue'
 import SideSheetButton from '@/components/layout/main-wrapper/side-sheet/SideSheetButton.vue'
+import SideSheetPanelLazyWrapper from '@/components/layout/main-wrapper/side-sheet/SideSheetPanelLazyWrapper.vue'
 import SideSheetArtistAlbumInfoSkeleton from '@/components/ui/skeletons/SideSheetArtistAlbumInfoSkeleton.vue'
+import SideSheetTabHeader from './SideSheetTabHeader.vue'
 
 const LyricsPane = defineAsyncComponent(() => import('@/components/ui/LyricsPane.vue'))
 const ArtistInfo = defineAsyncComponent(() => import('@/components/artist/ArtistInfo.vue'))
 const AlbumInfo = defineAsyncComponent(() => import('@/components/album/AlbumInfo.vue'))
 const YouTubeVideoList = defineAsyncComponent(() => import('@/components/ui/youtube/YouTubeVideoList.vue'))
-const SideSheetTabHeader = defineAsyncComponent(() => import('./SideSheetTabHeader.vue'))
 
 const { useYouTube } = useThirdPartyServices()
 
 const playable = requireInjection(CurrentPlayableKey, ref(undefined)) as Ref<Song | undefined>
-const activeTab = ref<ExtraPanelTab | null>(null)
+const activeTab = ref<SideSheetTab | null>(null)
+const activatedTabs = ref<SideSheetTab[]>([])
 
 const artist = ref<Artist>()
 const album = ref<Album>()
+const loadingArtist = ref(false)
+const loadingAlbum = ref(false)
 
 const songPlaying = computed(() => playable.value && isSong(playable.value))
 const shouldShowYouTubeTab = computed(() => useYouTube.value && songPlaying.value)
 
-const fetchSongInfo = async (song: Song) => {
-  playable.value = song
-  artist.value = undefined
-  album.value = undefined
+const shouldMountTab = (tab: SideSheetTab) => activatedTabs.value.includes(tab)
 
-  try {
-    artist.value = await artistStore.resolve(song.artist_id)
-    album.value = await albumStore.resolve(song.album_id)
-  } catch (error: unknown) {
-    useErrorHandler().handleHttpError(error)
+const maybeResolveArtist = async () => {
+  if (!songPlaying.value || playable.value!.artist_id === artist.value?.id) {
+    return
+  }
+
+  loadingArtist.value = true
+  artist.value = await artistStore.resolve(playable.value!.artist_id)
+  loadingArtist.value = false
+}
+
+const maybeResolveAlbum = async () => {
+  if (!songPlaying.value || playable.value!.album_id === album.value?.id) {
+    return
+  }
+
+  loadingAlbum.value = true
+  album.value = await albumStore.resolve(playable.value!.album_id)
+  loadingAlbum.value = false
+}
+
+const maybeResolveArtistOrAlbum = (activeTab: SideSheetTab | null = null) => {
+  switch (activeTab) {
+    case 'Artist':
+      return maybeResolveArtist()
+    case 'Album':
+      return maybeResolveAlbum()
+    default:
   }
 }
 
@@ -125,15 +146,35 @@ watch(playable, song => {
   if (!song || !isSong(song)) {
     return
   }
-  fetchSongInfo(song)
+
+  playable.value = song
+  maybeResolveArtistOrAlbum(activeTab.value)
 }, { immediate: true })
 
-watch(activeTab, tab => (preferenceStore.active_extra_panel_tab = tab))
+watch(activeTab, tab => {
+  if (!tab) {
+    return
+  }
+
+  preferenceStore.active_extra_panel_tab = tab
+
+  if (!activatedTabs.value.includes(tab)) {
+    activatedTabs.value.push(tab)
+  }
+
+  maybeResolveArtistOrAlbum(tab)
+})
 
 const onProfileLinkClick = () => isMobile.any && (activeTab.value = null)
 const expandSidebar = () => eventBus.emit('TOGGLE_SIDEBAR')
 
-onMounted(() => isMobile.any || (activeTab.value = preferenceStore.active_extra_panel_tab))
+onMounted(() => {
+  if (isMobile.any) {
+    return
+  }
+
+  activeTab.value = preferenceStore.active_extra_panel_tab
+})
 </script>
 
 <style lang="postcss" scoped>
@@ -149,8 +190,6 @@ onMounted(() => isMobile.any || (activeTab.value = preferenceStore.active_extra_
 
 aside {
   @media screen and (max-width: 768px) {
-    @mixin themed-background;
-
     &.showing-pane {
       height: 100%;
     }

--- a/resources/assets/js/components/layout/main-wrapper/side-sheet/SideSheetPanelLazyWrapper.vue
+++ b/resources/assets/js/components/layout/main-wrapper/side-sheet/SideSheetPanelLazyWrapper.vue
@@ -1,0 +1,20 @@
+<template>
+  <div v-if="shouldMount" v-show="active" role="tabpanel" tabindex="0">
+    <slot />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { toRefs } from 'vue'
+
+const props = withDefaults(defineProps<{ active?: boolean, shouldMount: boolean }>(), {
+  active: false,
+  shouldMount: false,
+})
+
+const { active, shouldMount } = toRefs(props)
+</script>
+
+<style scoped lang="postcss">
+
+</style>

--- a/resources/assets/js/components/layout/main-wrapper/side-sheet/SideSheetTabHeader.spec.ts
+++ b/resources/assets/js/components/layout/main-wrapper/side-sheet/SideSheetTabHeader.spec.ts
@@ -10,21 +10,21 @@ new class extends UnitTestCase {
       commonStore.state.uses_you_tube = false
       this.render(Component)
 
-      ;['Lyrics', 'Artist information', 'Album information'].forEach(name => screen.getByRole('button', { name }))
-      expect(screen.queryByRole('button', { name: 'Related YouTube videos' })).toBeNull()
+      ;['lyrics', 'artist', 'album'].forEach(name => screen.getByTestId(`side-sheet-${name}-tab-header`))
+      expect(screen.queryByTestId('side-sheet-youtube-tab-header')).toBeNull()
     })
 
     it('has a YouTube tab header if using YouTube', () => {
       commonStore.state.uses_you_tube = true
       this.render(Component)
 
-      screen.getByRole('button', { name: 'Related YouTube videos' })
+      screen.getByTestId('side-sheet-youtube-tab-header')
     })
 
     it('emits the selected tab value', async () => {
       const { emitted } = this.render(Component)
 
-      await this.user.click(screen.getByRole('button', { name: 'Lyrics' }))
+      await this.user.click(screen.getByTestId('side-sheet-lyrics-tab-header'))
 
       expect(emitted()['update:modelValue']).toEqual([['Lyrics']])
     })

--- a/resources/assets/js/components/layout/main-wrapper/side-sheet/SideSheetTabHeader.vue
+++ b/resources/assets/js/components/layout/main-wrapper/side-sheet/SideSheetTabHeader.vue
@@ -3,6 +3,8 @@
     id="extraTabLyrics"
     v-koel-tooltip.left
     :class="{ active: value === 'Lyrics' }"
+    data-testid="side-sheet-lyrics-tab-header"
+    role="tab"
     title="Lyrics"
     @click.prevent="toggleTab('Lyrics')"
   >
@@ -12,6 +14,8 @@
     id="extraTabArtist"
     v-koel-tooltip.left
     :class="{ active: value === 'Artist' }"
+    data-testid="side-sheet-artist-tab-header"
+    role="tab"
     title="Artist information"
     @click.prevent="toggleTab('Artist')"
   >
@@ -21,6 +25,8 @@
     id="extraTabAlbum"
     v-koel-tooltip.left
     :class="{ active: value === 'Album' }"
+    data-testid="side-sheet-album-tab-header"
+    role="tab"
     title="Album information"
     @click.prevent="toggleTab('Album')"
   >
@@ -31,6 +37,8 @@
     id="extraTabYouTube"
     v-koel-tooltip.left
     :class="{ active: value === 'YouTube' }"
+    data-testid="side-sheet-youtube-tab-header"
+    role="tab"
     title="Related YouTube videos"
     @click.prevent="toggleTab('YouTube')"
   >
@@ -47,11 +55,11 @@ import { useThirdPartyServices } from '@/composables/useThirdPartyServices'
 
 import SideSheetButton from '@/components/layout/main-wrapper/side-sheet/SideSheetButton.vue'
 
-const props = withDefaults(defineProps<{ modelValue?: ExtraPanelTab | null }>(), {
+const props = withDefaults(defineProps<{ modelValue?: SideSheetTab | null }>(), {
   modelValue: null,
 })
 
-const emit = defineEmits<{ (e: 'update:modelValue', value: ExtraPanelTab | null): void }>()
+const emit = defineEmits<{ (e: 'update:modelValue', value: SideSheetTab | null): void }>()
 
 const { useYouTube } = useThirdPartyServices()
 
@@ -60,5 +68,5 @@ const value = computed({
   set: value => emit('update:modelValue', value),
 })
 
-const toggleTab = (tab: ExtraPanelTab) => (value.value = value.value === tab ? null : tab)
+const toggleTab = (tab: SideSheetTab) => (value.value = value.value === tab ? null : tab)
 </script>

--- a/resources/assets/js/components/layout/main-wrapper/side-sheet/__snapshots__/SideSheet.spec.ts.snap
+++ b/resources/assets/js/components/layout/main-wrapper/side-sheet/__snapshots__/SideSheet.spec.ts.snap
@@ -2,14 +2,14 @@
 
 exports[`renders without a current song 1`] = `
 <aside data-v-9fd7deea="" class="fixed sm:relative top-0 w-screen md:w-auto flex flex-col md:flex-row-reverse z-[2] text-k-text-secondary">
-  <div data-v-9fd7deea="" class="controls flex md:flex-col justify-between items-center md:w-[64px] md:py-6 tw:px-0 bg-black/5 md:border-l border-solid md:border-l-white/5 md:border-b-0 md:shadow-none z-[2] w-screen flex-row border-b border-b-white/5 border-l-0 shadow-xl py-0 px-6 h-k-header-height">
+  <header data-v-9fd7deea="" class="controls flex md:flex-col justify-between items-center md:w-[64px] md:py-6 tw:px-0 bg-black/5 md:border-l border-solid md:border-l-white/5 md:border-b-0 md:shadow-none z-[2] w-screen flex-row border-b border-b-white/5 border-l-0 shadow-xl py-0 px-6 h-k-header-height">
     <div data-v-9fd7deea="" class="btn-group"><button data-v-7447146c="" data-v-9fd7deea="" class="relative flex items-center justify-center h-[42px] aspect-square rounded-full bg-none md:bg-black/30 text-xl opacity-70 transition-opacity duration-200 ease-in-out text-current cursor-pointer hover:active-state active:scale-90 md:hidden" type="button"><br data-v-9fd7deea="" data-testid="Icon" icon="[object Object]" fixed-width=""></button>
       <!--v-if-->
     </div>
     <div data-v-9fd7deea="" class="btn-group"><button data-v-7447146c="" data-v-9fd7deea="" class="relative flex items-center justify-center h-[42px] aspect-square rounded-full bg-none md:bg-black/30 text-xl opacity-70 transition-opacity duration-200 ease-in-out text-current cursor-pointer hover:active-state active:scale-90" type="button" title="About Koel"><br data-testid="Icon" icon="[object Object]">
         <!--v-if-->
-      </button><button data-v-7447146c="" data-v-9fd7deea="" class="relative flex items-center justify-center h-[42px] aspect-square rounded-full bg-none md:bg-black/30 text-xl opacity-70 transition-opacity duration-200 ease-in-out text-current cursor-pointer hover:active-state active:scale-90" type="button" title="Log out"><br data-testid="Icon" icon="[object Object]"></button><br data-v-9fd7deea="" data-testid="stub"></div>
-  </div>
+      </button><button data-v-7447146c="" data-v-9fd7deea="" class="relative flex items-center justify-center h-[42px] aspect-square rounded-full bg-none md:bg-black/30 text-xl opacity-70 transition-opacity duration-200 ease-in-out text-current cursor-pointer hover:active-state active:scale-90" type="button" title="Log out"><br data-testid="Icon" icon="[object Object]"></button><br data-v-9fd7deea="" data-testid="profile-avatar"></div>
+  </header>
   <!--v-if-->
 </aside>
 `;

--- a/resources/assets/js/components/ui/skeletons/ParagraphSkeleton.vue
+++ b/resources/assets/js/components/ui/skeletons/ParagraphSkeleton.vue
@@ -1,0 +1,10 @@
+<template>
+  <div class="skeleton flex flex-col gap-3">
+    <p v-for="i in (lines - 1)" :key="i" class="h-5 pulse" />
+    <p class="h-5 w-1/3 pulse" />
+  </div>
+</template>
+
+<script setup lang="ts">
+withDefaults(defineProps<{ lines?: number }>(), { lines: 4 })
+</script>

--- a/resources/assets/js/components/ui/skeletons/SideSheetArtistAlbumInfoSkeleton.vue
+++ b/resources/assets/js/components/ui/skeletons/SideSheetArtistAlbumInfoSkeleton.vue
@@ -3,14 +3,10 @@
     <div class="h-8 pulse" />
     <div class="aspect-square rounded-lg pulse" />
 
-    <div class="flex flex-col gap-3">
-      <p class="h-5 pulse" />
-      <p class="h-5 pulse" />
-      <p class="h-5 pulse" />
-      <p class="h-5 w-1/3 pulse" />
-    </div>
+    <ParagraphSkeleton />
   </article>
 </template>
 
 <script setup lang="ts">
+import ParagraphSkeleton from '@/components/ui/skeletons/ParagraphSkeleton.vue'
 </script>

--- a/resources/assets/js/components/ui/skeletons/YouTubeVideoListItemSkeleton.vue
+++ b/resources/assets/js/components/ui/skeletons/YouTubeVideoListItemSkeleton.vue
@@ -1,0 +1,12 @@
+<template>
+  <div class="skeleton flex gap-3">
+    <div class="w-[90px] h-[60px] pulse" />
+    <aside class="space-y-1 flex-1">
+      <ParagraphSkeleton :lines="3" />
+    </aside>
+  </div>
+</template>
+
+<script setup lang="ts">
+import ParagraphSkeleton from '@/components/ui/skeletons/ParagraphSkeleton.vue'
+</script>

--- a/resources/assets/js/components/ui/skeletons/YouTubeVideoListSkeleton.vue
+++ b/resources/assets/js/components/ui/skeletons/YouTubeVideoListSkeleton.vue
@@ -1,0 +1,9 @@
+<template>
+  <div class="skeleton space-y-5">
+    <YouTubeVideoListItemSkeleton v-for="i in 4" :key="i" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import YouTubeVideoListItemSkeleton from '@/components/ui/skeletons/YouTubeVideoListItemSkeleton.vue'
+</script>

--- a/resources/assets/js/components/ui/youtube/YouTubeVideoList.vue
+++ b/resources/assets/js/components/ui/youtube/YouTubeVideoList.vue
@@ -9,7 +9,7 @@
       <Btn v-if="!loading" small @click.prevent="loadMore">Load More</Btn>
     </template>
 
-    <p v-if="loading">Loading…</p>
+    <YouTubeVideoListSkeleton v-if="loading" />
 
     <p v-if="somethingWrong">
       Failed to load videos.
@@ -26,6 +26,7 @@ import { useErrorHandler } from '@/composables/useErrorHandler'
 const props = defineProps<{ song: Song }>()
 const Btn = defineAsyncComponent(() => import('@/components/ui/form/Btn.vue'))
 const YouTubeVideo = defineAsyncComponent(() => import('@/components/ui/youtube/YouTubeVideoItem.vue'))
+const YouTubeVideoListSkeleton = defineAsyncComponent(() => import('@/components/ui/skeletons/YouTubeVideoListSkeleton.vue'))
 
 const { song } = toRefs(props)
 

--- a/resources/assets/js/stores/preferenceStore.ts
+++ b/resources/assets/js/stores/preferenceStore.ts
@@ -61,7 +61,7 @@ const preferenceStore = {
     this.state[key] = value
 
     if (!this._temporary) {
-      http.silently.patch('me/preferences', { key, value })
+      this.update(key, value)
     } else {
       this._temporary = false
     }
@@ -69,6 +69,10 @@ const preferenceStore = {
 
   get (key: keyof UserPreferences) {
     return this.state?.[key]
+  },
+
+  update (key: keyof UserPreferences, value: any) {
+    http.silently.patch('me/preferences', { key, value })
   },
 
   // Calling preferenceStore.temporary.volume = 7 won't trigger saving.
@@ -79,7 +83,7 @@ const preferenceStore = {
   },
 }
 
-type ExportedType = Omit<typeof preferenceStore, 'setupProxy' | '_temporary'> & UserPreferences
+type ExportedType = Omit<typeof preferenceStore, 'setupProxy' | '_temporary' | 'update'> & UserPreferences
 
 const exported = preferenceStore as unknown as ExportedType
 

--- a/resources/assets/js/types.d.ts
+++ b/resources/assets/js/types.d.ts
@@ -319,7 +319,7 @@ interface UserPreferences extends Record<string, any> {
   lyrics_zoom_level: number | null
   theme?: Theme['id'] | null
   visualizer?: Visualizer['id'] | null
-  active_extra_panel_tab: ExtraPanelTab | null
+  active_extra_panel_tab: SideSheetTab | null
   make_uploads_public: boolean
   lastfm_session_key?: string
 }
@@ -508,7 +508,7 @@ interface Genre {
   length: number
 }
 
-type ExtraPanelTab = 'Lyrics' | 'Artist' | 'Album' | 'YouTube'
+type SideSheetTab = 'Lyrics' | 'Artist' | 'Album' | 'YouTube'
 
 interface Visualizer {
   init: (container: HTMLElement) => Promise<Closure>


### PR DESCRIPTION
This PR makes the sidesheet content (album, artist, and other info) load on demand, i.e., only when the user activates the corresponding tabs. Loading skeletons have also been added for a better UX.