### PR TITLE
feat: add album cover to full screen

### DIFF
--- a/app/Http/Resources/SongResource.php
+++ b/app/Http/Resources/SongResource.php
@@ -26,6 +26,7 @@ class SongResource extends JsonResource
         'album_artist_id',
         'album_artist_name',
         'album_cover',
+        'full_screen_cover',
         'length',
         'liked',
         'play_count',
@@ -99,6 +100,7 @@ class SongResource extends JsonResource
             'album_artist_id' => $this->unless($embedding, $this->song->album_artist?->id),
             'album_artist_name' => $this->unless($embedding, $this->song->album_artist?->name),
             'album_cover' => $this->song->album?->cover,
+            'full_screen_cover' => $this->song->album?->full_screen_cover,
             'length' => $this->song->length,
             'liked' => $this->unless($embedding, $this->song->favorite), // backwards compatibility
             'favorite' => $this->unless($embedding, $this->song->favorite),

--- a/app/Observers/AlbumObserver.php
+++ b/app/Observers/AlbumObserver.php
@@ -23,7 +23,12 @@ class AlbumObserver
                 $parts = pathinfo($oldCoverPath);
 
                 $oldThumbnail = sprintf('%s_thumb.%s', $parts['filename'], $parts['extension']);
-                File::delete([$oldCoverPath, image_storage_path($oldThumbnail)]);
+                $oldFullScreenCover = sprintf('%s_fullscreen.%s', $parts['filename'], $parts['extension']);
+                File::delete([
+                    $oldCoverPath,
+                    image_storage_path($oldThumbnail),
+                    image_storage_path($oldFullScreenCover),
+                ]);
             },
         );
     }
@@ -42,7 +47,7 @@ class AlbumObserver
     {
         rescue_if(
             $album->has_cover,
-            static fn () => File::delete([$album->cover_path, $album->thumbnail_path]),
+            static fn () => File::delete([$album->cover_path, $album->thumbnail_path, $album->full_screen_cover_path]),
         );
     }
 }

--- a/app/Services/ImageStorage.php
+++ b/app/Services/ImageStorage.php
@@ -37,7 +37,7 @@ class ImageStorage
             $album->save();
 
             $this->createThumbnailForAlbum($album);
-
+            $this->createFullScreenCoverForAlbum($album, $source);
             return $album->cover;
         });
     }
@@ -83,6 +83,13 @@ class ImageStorage
         $this->imageWriter->write($album->thumbnail_path, $album->cover_path, ImageWritingConfig::make(
             maxWidth: 48,
             blur: 10,
+        ));
+    }
+
+    private function createFullScreenCoverForAlbum(Album $album, string $source): void
+    {
+        $this->imageWriter->write($album->full_screen_cover_path, $source, ImageWritingConfig::make(
+            maxWidth: 1920
         ));
     }
 

--- a/resources/assets/js/components/layout/app-footer/index.vue
+++ b/resources/assets/js/components/layout/app-footer/index.vue
@@ -9,6 +9,8 @@
 
     <div class="fullscreen-backdrop hidden" />
 
+    <div class="album-cover-layer hidden" />
+
     <div class="wrapper relative flex flex-1">
       <RadioStationInfo v-if="isRadio" />
       <SongInfo v-else />
@@ -104,6 +106,19 @@ const appBackgroundImage = computed(() => {
   return src ? `url(${src})` : 'none'
 })
 
+const albumCoverImage = computed(() => {
+  if (!currentStreamable.value) {
+    return 'none'
+  }
+
+  if (isSong(currentStreamable.value)) {
+    const src = currentStreamable.value.full_screen_cover || currentStreamable.value.album_cover
+    return src ? `url(${src})` : 'none'
+  }
+
+  return 'none'
+})
+
 const initPlaybackRelatedServices = async () => {
   const plyrWrapper = document.querySelector<HTMLElement>('.plyr')
 
@@ -176,11 +191,15 @@ footer {
     background-image: v-bind(appBackgroundImage);
   }
 
+  .album-cover-layer {
+    background-image: v-bind(albumCoverImage);
+  }
+
   &:fullscreen {
     padding: calc(100vh - 9rem) 5vw 0;
     @apply bg-none;
 
-    &.hide-controls :not(.fullscreen-backdrop, .up-next, .up-next *) {
+    &.hide-controls :not(.fullscreen-backdrop, .album-cover-layer, .up-next, .up-next *) {
       transition: opacity 2s ease-in-out !important; /* overriding all children's custom transition, if any */
       @apply opacity-0;
     }
@@ -214,6 +233,11 @@ footer {
 
     .fullscreen-backdrop {
       @apply saturate-[0.2] block absolute top-0 left-0 w-full h-full z-0 bg-cover bg-no-repeat bg-top;
+    }
+
+    .album-cover-layer {
+      @apply block absolute top-0 left-0 w-full h-full z-[1] bg-no-repeat bg-center pointer-events-none;
+      background-size: contain;
     }
   }
 }

--- a/tests/Feature/SongFullScreenCoverTest.php
+++ b/tests/Feature/SongFullScreenCoverTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Album;
+use App\Models\Song;
+use Illuminate\Support\Facades\File;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SongFullScreenCoverTest extends TestCase
+{
+    #[Test]
+    public function songReturnsFullScreenCoverUrlIfFileExists(): void
+    {
+        /** @var Album $album */
+        $album = Album::factory()->create([
+            'cover' => 'foo.jpg',
+        ]);
+
+        File::put(image_storage_path('foo_fullscreen.jpg'), 'fake');
+
+        /** @var Song $song */
+        $song = Song::factory()->for($album)->create();
+
+        $this->getAs("api/songs/{$song->id}")
+            ->assertJson([
+                'full_screen_cover' => image_storage_url('foo_fullscreen.jpg'),
+            ]);
+    }
+
+    #[Test]
+    public function songReturnsNullIfFullScreenCoverIsMissing(): void
+    {
+        /** @var Album $album */
+        $album = Album::factory()->create([
+            'cover' => 'bar.jpg',
+        ]);
+
+        /** @var Song $song */
+        $song = Song::factory()->for($album)->create();
+
+        $this->getAs("api/songs/{$song->id}")
+            ->assertJson([
+                'full_screen_cover' => null,
+            ]);
+    }
+}

--- a/tests/Unit/Services/ImageStorageTest.php
+++ b/tests/Unit/Services/ImageStorageTest.php
@@ -8,6 +8,7 @@ use App\Models\Artist;
 use App\Services\ImageStorage;
 use App\Services\ImageWriter;
 use App\Services\SvgSanitizer;
+use App\Values\ImageWritingConfig;
 use Illuminate\Support\Facades\File;
 use Mockery;
 use Mockery\MockInterface;
@@ -41,10 +42,34 @@ class ImageStorageTest extends TestCase
         $coverPath = '/koel/public/img/album/foo.jpg';
 
         $this->imageWriter
-            ->expects('write')
+            ->shouldReceive('write')
+            ->once()
             ->with('/koel/public/img/album/foo.jpg', 'dummy-src');
 
-        $this->imageWriter->expects('write');
+        $this->imageWriter
+            ->shouldReceive('write')
+            ->once()
+            ->with(
+                image_storage_path('foo_thumb.jpg'),
+                image_storage_path('foo.jpg'),
+                Mockery::on(static function ($config) {
+                    return $config instanceof ImageWritingConfig
+                        && $config->maxWidth === 48
+                        && $config->blur === 10;
+                })
+            );
+
+        $this->imageWriter
+            ->shouldReceive('write')
+            ->once()
+            ->with(
+                image_storage_path('foo_fullscreen.jpg'),
+                'dummy-src',
+                Mockery::on(static function ($config) {
+                    return $config instanceof ImageWritingConfig
+                        && $config->maxWidth === 1920;
+                })
+            );
 
         $cover = $this->service->storeAlbumCover($album, 'dummy-src', $coverPath);
 


### PR DESCRIPTION
## Description
This adds a full album cover image on top of the existing backdrop when in fullscreen mode.
To ensure good image quality, a new 1920 px version has been added, with a fallback to the existing 500 px image.

## Motivation
Personally, I felt the album cover was previously underrepresented — when an artist image was available, it wasn’t shown at all, and otherwise only appeared as a cropped black-and-white version.

## Screenshots (if applicable)
<img width="1920" height="1080" alt="Screenshot 2025-10-19 at 18-17-59 21st Century ♫ Koel" src="https://github.com/user-attachments/assets/78e85f01-1ffd-470c-b00a-b5892d2d4fb1" />


## Checklist
- [ ✅ ] I've tested my changes thoroughly and added tests where applicable
- [ ✅] I've updated relevant documentation (if any)
- [ ✅] My code follows the project's conventions


Unfortunately, the original image was no longer available, so I couldn't generate new thumbnails with higher resolution.
As a result, the existing albums will all have a 500 px resolution.
I tried to refactor the code so that the original image would always be persisted (for future changes), but this would affect many other parts of the system (artists, playlists, etc.).
Therefore, I think it’s out of scope for this PR, and I don’t know the codebase well enough to predict all potential side effects.

I don’t have access to any third-party integrations (like spotify), so I wasn’t able to test this with them.
