### PR TITLE
refactor: simplify all those image urls and paths

### DIFF
--- a/app/Helpers.php
+++ b/app/Helpers.php
@@ -27,14 +27,14 @@ function base_url(): string
     return app()->runningUnitTests() ? config('app.url') : asset('');
 }
 
-function image_storage_path(?string $fileName): ?string
+function image_storage_path(?string $fileName, ?string $default = null): ?string
 {
-    return $fileName ? public_path(config('koel.image_storage_dir') . $fileName) : null;
+    return $fileName ? public_path(config('koel.image_storage_dir') . $fileName) : $default;
 }
 
-function image_storage_url(?string $fileName): ?string
+function image_storage_url(?string $fileName, ?string $default = null): ?string
 {
-    return $fileName ? static_url(config('koel.image_storage_dir') . $fileName) : null;
+    return $fileName ? static_url(config('koel.image_storage_dir') . $fileName) : $default;
 }
 
 function artifact_path(?string $subPath = null, $ensureDirectoryExists = true): string

--- a/app/Http/Controllers/API/AlbumCoverController.php
+++ b/app/Http/Controllers/API/AlbumCoverController.php
@@ -21,7 +21,7 @@ class AlbumCoverController extends Controller
         $this->authorize('update', $album);
         $this->imageStorage->storeAlbumCover($album, $request->getFileContent());
 
-        return response()->json(['cover_url' => $album->cover]);
+        return response()->json(['cover_url' => image_storage_url($album->cover)]);
     }
 
     public function destroy(Album $album)

--- a/app/Http/Controllers/API/Artist/ArtistImageController.php
+++ b/app/Http/Controllers/API/Artist/ArtistImageController.php
@@ -21,7 +21,7 @@ class ArtistImageController extends Controller
         $this->authorize('update', $artist);
         $this->imageStorage->storeArtistImage($artist, $request->getFileContent());
 
-        return response()->json(['image_url' => $artist->image]);
+        return response()->json(['image_url' => image_storage_url($artist->image)]);
     }
 
     public function destroy(Artist $artist)

--- a/app/Http/Controllers/API/FetchAlbumThumbnailController.php
+++ b/app/Http/Controllers/API/FetchAlbumThumbnailController.php
@@ -10,6 +10,8 @@ class FetchAlbumThumbnailController extends Controller
 {
     public function __invoke(Album $album, ImageStorage $imageStorage)
     {
-        return response()->json(['thumbnailUrl' => $imageStorage->getAlbumThumbnailUrl($album)]);
+        return response()->json([
+            'thumbnailUrl' => image_storage_url($imageStorage->getOrCreateAlbumThumbnail($album)), // @todo snake_case
+        ]);
     }
 }

--- a/app/Http/Controllers/API/PlaylistCoverController.php
+++ b/app/Http/Controllers/API/PlaylistCoverController.php
@@ -19,7 +19,7 @@ class PlaylistCoverController extends Controller
         $this->authorize('own', $playlist);
         $updated = $this->playlistService->updatePlaylistCover($playlist, $request->getFileContent());
 
-        return response()->json(['cover_url' => $updated->cover]);
+        return response()->json(['cover_url' => image_storage_url($updated->cover)]);
     }
 
     public function destroy(Playlist $playlist)

--- a/app/Http/Resources/AlbumResource.php
+++ b/app/Http/Resources/AlbumResource.php
@@ -67,7 +67,7 @@ class AlbumResource extends JsonResource
             'name' => $this->album->name,
             'artist_id' => $this->album->artist->id,
             'artist_name' => $this->album->artist->name,
-            'cover' => $this->album->cover,
+            'cover' => image_storage_url($this->album->cover),
             'created_at' => $this->unless($embedding, $this->album->created_at),
             'year' => $this->album->year,
             'is_external' => $this->unless(

--- a/app/Http/Resources/ArtistResource.php
+++ b/app/Http/Resources/ArtistResource.php
@@ -61,7 +61,7 @@ class ArtistResource extends JsonResource
             'type' => 'artists',
             'id' => $this->artist->id,
             'name' => $this->artist->name,
-            'image' => $this->artist->image,
+            'image' => image_storage_url($this->artist->image),
             'created_at' => $this->unless($embedding, $this->artist->created_at),
             'is_external' => $this->unless(
                 $embedding,

--- a/app/Http/Resources/PlaylistResource.php
+++ b/app/Http/Resources/PlaylistResource.php
@@ -42,7 +42,7 @@ class PlaylistResource extends JsonResource
             'is_smart' => $this->unless($embedding, $this->playlist->is_smart),
             'is_collaborative' => $this->unless($embedding, $this->playlist->is_collaborative),
             'rules' => $this->unless($embedding, $this->playlist->rules),
-            'cover' => $this->playlist->cover,
+            'cover' => image_storage_url($this->playlist->cover),
             'created_at' => $this->unless($embedding, $this->playlist->created_at),
         ];
     }

--- a/app/Http/Resources/RadioStationResource.php
+++ b/app/Http/Resources/RadioStationResource.php
@@ -32,7 +32,7 @@ class RadioStationResource extends JsonResource
             'name' => $this->station->name,
             'id' => $this->station->id,
             'url' => $this->station->url,
-            'logo' => $this->station->logo,
+            'logo' => image_storage_url($this->station->logo),
             'description' => $this->station->description,
             'is_public' => $this->station->is_public,
             'created_at' => $this->station->created_at,

--- a/app/Http/Resources/SongResource.php
+++ b/app/Http/Resources/SongResource.php
@@ -98,7 +98,7 @@ class SongResource extends JsonResource
             'artist_name' => $this->song->artist?->name,
             'album_artist_id' => $this->unless($embedding, $this->song->album_artist?->id),
             'album_artist_name' => $this->unless($embedding, $this->song->album_artist?->name),
-            'album_cover' => $this->song->album?->cover,
+            'album_cover' => image_storage_url($this->song->album?->cover),
             'length' => $this->song->length,
             'liked' => $this->unless($embedding, $this->song->favorite), // backwards compatibility
             'favorite' => $this->unless($embedding, $this->song->favorite),

--- a/app/Models/Artist.php
+++ b/app/Models/Artist.php
@@ -19,24 +19,20 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\File;
 use Laravel\Scout\Searchable;
 use OwenIt\Auditing\Auditable;
 use OwenIt\Auditing\Contracts\Auditable as AuditableContract;
 
 /**
- * @property ?string $image Public URL to the artist's image
- * @property ?string $image_path Absolute path to the artist's image
+ * @property ?string $image The artist's image file name
  * @property Carbon $created_at
  * @property Collection<array-key, Album> $albums
  * @property Collection<array-key, Song> $songs
  * @property User $user
- * @property bool $has_image If the artist has a (non-default) image
  * @property bool $is_unknown If the artist is Unknown Artist
  * @property bool $is_various If the artist is Various Artist
- * @property string $id
  * @property int $user_id The ID of the user that owns this artist
+ * @property string $id
  * @property string $name
  */
 class Artist extends Model implements AuditableContract, Embeddable, Favoriteable, Permissionable
@@ -134,28 +130,6 @@ class Artist extends Model implements AuditableContract, Embeddable, Favoriteabl
     protected function name(): Attribute
     {
         return Attribute::get(static fn (string $value): string => html_entity_decode($value) ?: self::UNKNOWN_NAME);
-    }
-
-    /**
-     * Turn the image name into its absolute URL.
-     */
-    protected function image(): Attribute
-    {
-        return Attribute::get(static fn (?string $value): ?string => image_storage_url($value));
-    }
-
-    protected function imagePath(): Attribute
-    {
-        return Attribute::get(fn (): ?string => image_storage_path(Arr::get($this->attributes, 'image')));
-    }
-
-    protected function hasImage(): Attribute
-    {
-        return Attribute::get(function (): bool {
-            $image = Arr::get($this->attributes, 'image');
-
-            return $image && (app()->runningUnitTests() || File::exists(image_storage_path($image)));
-        });
     }
 
     /** @return array<mixed> */

--- a/app/Models/Playlist.php
+++ b/app/Models/Playlist.php
@@ -16,7 +16,6 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Laravel\Scout\Searchable;
 use OwenIt\Auditing\Auditable;
@@ -34,8 +33,7 @@ use OwenIt\Auditing\Contracts\Auditable as AuditableContract;
  * @property EloquentCollection<array-key, Playable> $playables
  * @property EloquentCollection<array-key, User> $users
  * @property EloquentCollection<array-key, User> $collaborators
- * @property ?string $cover The playlist cover's URL
- * @property-read ?string $cover_path
+ * @property ?string $cover The playlist cover's file name
  * @property-read EloquentCollection<array-key, PlaylistFolder> $folders
  * @property-read bool $is_collaborative
  * @property int $owner_id
@@ -102,20 +100,6 @@ class Playlist extends Model implements AuditableContract, Embeddable
     {
         // aliasing the attribute to avoid confusion
         return Attribute::get(fn () => $this->rules);
-    }
-
-    protected function cover(): Attribute
-    {
-        return Attribute::get(static fn (?string $value): ?string => image_storage_url($value))->shouldCache();
-    }
-
-    protected function coverPath(): Attribute
-    {
-        return Attribute::get(function () {
-            $cover = Arr::get($this->attributes, 'cover');
-
-            return $cover ? image_storage_path($cover) : null;
-        })->shouldCache();
     }
 
     public function ownedBy(User $user): bool

--- a/app/Models/RadioStation.php
+++ b/app/Models/RadioStation.php
@@ -7,12 +7,10 @@ use App\Models\Concerns\MorphsToFavorites;
 use App\Models\Contracts\Favoriteable;
 use App\Models\Contracts\Permissionable;
 use Carbon\Carbon;
-use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Support\Arr;
 use Laravel\Scout\Searchable;
 use OwenIt\Auditing\Auditable;
 use OwenIt\Auditing\Contracts\Auditable as AuditableContract;
@@ -22,8 +20,7 @@ use OwenIt\Auditing\Contracts\Auditable as AuditableContract;
  * @property int $user_id
  * @property User $user
  * @property string $url
- * @property ?string $logo The URL of the station's logo
- * @property ?string $logo_path The path to the station's logo
+ * @property ?string $logo The station's logo file name
  * @property ?string $description
  * @property boolean $is_public
  * @property Carbon|string $created_at
@@ -64,20 +61,6 @@ class RadioStation extends Model implements AuditableContract, Favoriteable, Per
     public function newEloquentBuilder($query): RadioStationBuilder
     {
         return new RadioStationBuilder($query);
-    }
-
-    protected function logo(): Attribute
-    {
-        return Attribute::get(static fn (?string $value): ?string => image_storage_url($value))->shouldCache();
-    }
-
-    protected function logoPath(): Attribute
-    {
-        return Attribute::get(function () {
-            $logo = Arr::get($this->attributes, 'logo');
-
-            return $logo ? image_storage_path($logo) : null;
-        })->shouldCache();
     }
 
     /** @inheritdoc */

--- a/app/Observers/AlbumObserver.php
+++ b/app/Observers/AlbumObserver.php
@@ -40,9 +40,9 @@ class AlbumObserver
 
     public function deleted(Album $album): void
     {
-        rescue_if(
-            $album->has_cover,
-            static fn () => File::delete([$album->cover_path, $album->thumbnail_path]),
-        );
+        $coverPath = image_storage_path($album->cover);
+        $thumbnailPath = image_storage_path($album->thumbnail);
+
+        rescue_if($coverPath || $thumbnailPath, static fn () => File::delete([$coverPath, $thumbnailPath]));
     }
 }

--- a/app/Observers/ArtistObserver.php
+++ b/app/Observers/ArtistObserver.php
@@ -31,6 +31,6 @@ class ArtistObserver
 
     public function deleted(Artist $artist): void
     {
-        rescue_if($artist->has_image, static fn () => File::delete($artist->image_path));
+        rescue_if($artist->image, static fn () => File::delete(image_storage_url($artist->image)));
     }
 }

--- a/app/Observers/PlaylistObserver.php
+++ b/app/Observers/PlaylistObserver.php
@@ -21,6 +21,6 @@ class PlaylistObserver
 
     public function deleted(Playlist $playlist): void
     {
-        rescue_if($playlist->cover_path, static fn () => File::delete($playlist->cover_path));
+        rescue_if($playlist->cover, static fn () => File::delete(image_storage_path($playlist->cover)));
     }
 }

--- a/app/Observers/RadioStationObserver.php
+++ b/app/Observers/RadioStationObserver.php
@@ -7,10 +7,6 @@ use Illuminate\Support\Facades\File;
 
 class RadioStationObserver
 {
-    public function created(RadioStation $radioStation): void
-    {
-    }
-
     public function updating(RadioStation $radioStation): void
     {
         if (!$radioStation->isDirty('logo')) {
@@ -25,12 +21,8 @@ class RadioStationObserver
         );
     }
 
-    public function updated(RadioStation $radioStation): void
-    {
-    }
-
     public function deleted(RadioStation $radioStation): void
     {
-        rescue_if($radioStation->logo_path, static fn (string $path) => File::delete($path));
+        rescue_if($radioStation->logo, static fn () => File::delete(image_storage_path($radioStation->logo)));
     }
 }

--- a/app/Services/EncyclopediaService.php
+++ b/app/Services/EncyclopediaService.php
@@ -30,7 +30,7 @@ class EncyclopediaService
             function () use ($album): AlbumInformation {
                 $info = $this->encyclopedia->getAlbumInformation($album) ?: AlbumInformation::make();
 
-                if ($album->has_cover || (!SpotifyService::enabled() && !$info->cover)) {
+                if ($album->cover || (!SpotifyService::enabled() && !$info->cover)) {
                     // If the album already has a cover, or there's no resource to download a cover from,
                     // just return the info.
                     return $info;
@@ -60,7 +60,7 @@ class EncyclopediaService
             function () use ($artist): ArtistInformation {
                 $info = $this->encyclopedia->getArtistInformation($artist) ?: ArtistInformation::make();
 
-                if ($artist->has_image || (!SpotifyService::enabled() && !$info->image)) {
+                if ($artist->image || (!SpotifyService::enabled() && !$info->image)) {
                     // If the artist already has an image, or there's no resource to download an image from,
                     // just return the info.
                     return $info;

--- a/app/Services/SongService.php
+++ b/app/Services/SongService.php
@@ -26,6 +26,7 @@ use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
 
 class SongService
 {
@@ -230,7 +231,9 @@ class SongService
 
         $album = $this->resolveAlbum($albumArtist, Arr::get($data, 'album'));
 
-        if (!$album->has_cover && !in_array('cover', $config->ignores, true)) {
+        $hasCover = $album->cover && File::exists(image_storage_path($album->cover));
+
+        if (!$hasCover && !in_array('cover', $config->ignores, true)) {
             $coverData = Arr::get($data, 'cover.data');
 
             if ($coverData) {

--- a/resources/assets/js/components/ui/SearchForm.vue
+++ b/resources/assets/js/components/ui/SearchForm.vue
@@ -55,7 +55,7 @@ let onInput = () => {
   _q && eventBus.emit('SEARCH_KEYWORDS_CHANGED', _q)
 }
 
-if (process.env.NODE_ENV !== 'test') {
+if (!window.RUNNING_UNIT_TESTS) {
   onInput = debounce(onInput, 500)
 }
 

--- a/resources/assets/js/composables/usePlayableListColumnVisibility.ts
+++ b/resources/assets/js/composables/usePlayableListColumnVisibility.ts
@@ -30,7 +30,7 @@ export const usePlayableListColumnVisibility = () => {
       columns.push('title')
       return Array.from(new Set(columns))
     } catch (error: unknown) {
-      process.env.NODE_ENV !== 'test' && logger.error('Failed to load columns from local storage', error)
+      window.RUNNING_UNIT_TESTS || logger.error('Failed to load columns from local storage', error)
       return defaultColumns
     }
   }

--- a/resources/assets/js/services/BasePlaybackService.ts
+++ b/resources/assets/js/services/BasePlaybackService.ts
@@ -57,7 +57,7 @@ export abstract class BasePlaybackService {
     listen('error', this.onError.bind(this), true)
     listen('ended', this.onEnded.bind(this))
 
-    const timeUpdateHandler = process.env.NODE_ENV === 'test' ? this.onTimeUpdate : throttle(this.onTimeUpdate, 1000)
+    const timeUpdateHandler = window.RUNNING_UNIT_TESTS ? this.onTimeUpdate : throttle(this.onTimeUpdate, 1000)
     listen('timeupdate', timeUpdateHandler.bind(this))
   }
 

--- a/resources/assets/js/utils/helpers.ts
+++ b/resources/assets/js/utils/helpers.ts
@@ -93,7 +93,7 @@ export const openPopup = (url: string, name: string, width: number, height: numb
  * This is handy for certain cases, for example Last.fm connect/disconnect.
  */
 export const forceReloadWindow = (): void => {
-  if (process.env.NODE_ENV === 'test') {
+  if (window.RUNNING_UNIT_TESTS) {
     return
   }
 

--- a/resources/assets/js/utils/supports.ts
+++ b/resources/assets/js/utils/supports.ts
@@ -14,7 +14,7 @@ const iOS = () => [
  * Notice that event though iOS technically supports AudioContext, turning it on will cause a problem
  * where switching to another app will pause script execution and mute the audio.
  */
-export const isAudioContextSupported = process.env.NODE_ENV !== 'test' && !iOS()
+export const isAudioContextSupported = !window.RUNNING_UNIT_TESTS && !iOS()
 
 /**
  * Checks if the browser supports reading (and thus uploading) a whole directory.

--- a/tests/Feature/AlbumCoverTest.php
+++ b/tests/Feature/AlbumCoverTest.php
@@ -26,7 +26,7 @@ class AlbumCoverTest extends TestCase
         $this->deleteAs("api/albums/{$album->id}/cover", [], create_admin())
             ->assertNoContent();
 
-        self::assertNull($album->refresh()->cover);
+        self::assertEmpty($album->refresh()->cover);
         self::assertFileDoesNotExist(image_storage_path($file));
     }
 
@@ -39,6 +39,6 @@ class AlbumCoverTest extends TestCase
         $this->deleteAs("api/albums/{$album->id}/cover")
             ->assertForbidden();
 
-        self::assertNotNull($album->refresh()->cover);
+        self::assertNotEmpty($album->refresh()->cover);
     }
 }

--- a/tests/Feature/AlbumTest.php
+++ b/tests/Feature/AlbumTest.php
@@ -84,7 +84,7 @@ class AlbumTest extends TestCase
 
         self::assertEquals('Updated Album Name', $album->name);
         self::assertEquals(2023, $album->year);
-        self::assertEquals(image_storage_url("$ulid.webp"), $album->cover);
+        self::assertEquals("$ulid.webp", $album->cover);
     }
 
     #[Test]

--- a/tests/Feature/AlbumThumbnailTest.php
+++ b/tests/Feature/AlbumThumbnailTest.php
@@ -24,24 +24,24 @@ class AlbumThumbnailTest extends TestCase
     /** @return array<mixed> */
     public static function provideAlbumThumbnailData(): array
     {
-        return [['http://localhost/img/covers/foo_thumbnail.jpg'], [null]];
+        return [['foo_thumbnail.jpg'], [null]];
     }
 
     #[DataProvider('provideAlbumThumbnailData')]
     #[Test]
-    public function getAlbumThumbnail(?string $thumbnailUrl): void
+    public function getAlbumThumbnail(?string $fileName): void
     {
         /** @var Album $createdAlbum */
         $createdAlbum = Album::factory()->create();
 
         $this->imageStorage
-            ->expects('getAlbumThumbnailUrl')
+            ->expects('getOrCreateAlbumThumbnail')
             ->with(Mockery::on(static function (Album $album) use ($createdAlbum): bool {
                 return $album->id === $createdAlbum->id;
             }))
-            ->andReturn($thumbnailUrl);
+            ->andReturn($fileName);
 
         $response = $this->getAs("api/albums/{$createdAlbum->id}/thumbnail");
-        $response->assertJson(['thumbnailUrl' => $thumbnailUrl]);
+        $response->assertJson(['thumbnailUrl' => image_storage_url($fileName)]);
     }
 }

--- a/tests/Feature/ArtistImageTest.php
+++ b/tests/Feature/ArtistImageTest.php
@@ -26,7 +26,7 @@ class ArtistImageTest extends TestCase
         $this->deleteAs("api/artists/{$artist->id}/image", [], create_admin())
             ->assertNoContent();
 
-        self::assertNull($artist->refresh()->image);
+        self::assertEmpty($artist->refresh()->image);
         self::assertFileDoesNotExist(image_storage_path($file));
     }
 
@@ -39,6 +39,6 @@ class ArtistImageTest extends TestCase
         $this->deleteAs("api/artists/{$artist->id}/image")
             ->assertForbidden();
 
-        self::assertNotNull($artist->refresh()->image);
+        self::assertNotEmpty($artist->refresh()->image);
     }
 }

--- a/tests/Feature/ArtistTest.php
+++ b/tests/Feature/ArtistTest.php
@@ -77,7 +77,7 @@ class ArtistTest extends TestCase
         $artist->refresh();
 
         self::assertEquals('Updated Artist Name', $artist->name);
-        self::assertEquals(image_storage_url("$ulid.webp"), $artist->image);
+        self::assertEquals("$ulid.webp", $artist->image);
     }
 
     #[Test]

--- a/tests/Feature/PlaylistCoverTest.php
+++ b/tests/Feature/PlaylistCoverTest.php
@@ -33,7 +33,7 @@ class PlaylistCoverTest extends TestCase
         $this->deleteAs("api/playlists/{$playlist->id}/cover", [], create_user())
             ->assertForbidden();
 
-        self::assertSame(image_storage_url('foo.webp'), $playlist->refresh()->cover);
+        self::assertSame('foo.webp', $playlist->refresh()->cover);
         self::assertFileExists(image_storage_path('foo.webp'));
     }
 }

--- a/tests/Integration/Services/AlbumServiceTest.php
+++ b/tests/Integration/Services/AlbumServiceTest.php
@@ -70,7 +70,7 @@ class AlbumServiceTest extends TestCase
 
         self::assertEquals('New Album Name', $updatedAlbum->name);
         self::assertEquals(2023, $updatedAlbum->year);
-        self::assertEquals(image_storage_url("$ulid.webp"), $updatedAlbum->cover);
+        self::assertEquals("$ulid.webp", $updatedAlbum->cover);
 
         $songs->each(static function (Song $song) use ($updatedAlbum): void {
             self::assertEquals($updatedAlbum->name, $song->fresh()->album_name);
@@ -104,7 +104,7 @@ class AlbumServiceTest extends TestCase
 
         $this->service->removeAlbumCover($album);
 
-        self::assertNull($album->refresh()->cover);
+        self::assertEmpty($album->refresh()->cover);
         self::assertFileDoesNotExist(image_storage_path("$ulid.webp"));
         self::assertFileDoesNotExist(image_storage_path("{$ulid}_thumb.webp"));
     }

--- a/tests/Integration/Services/ArtistServiceTest.php
+++ b/tests/Integration/Services/ArtistServiceTest.php
@@ -67,7 +67,7 @@ class ArtistServiceTest extends TestCase
         $updatedArtist = $this->service->updateArtist($artist, $data);
 
         self::assertEquals('New Artist Name', $updatedArtist->name);
-        self::assertEquals(image_storage_url("$ulid.webp"), $updatedArtist->image);
+        self::assertEquals("$ulid.webp", $updatedArtist->image);
 
         $songs->each(static function (Song $song) use ($updatedArtist): void {
             self::assertEquals($updatedArtist->name, $song->fresh()->artist_name);

--- a/tests/Integration/Services/EncyclopediaServiceTest.php
+++ b/tests/Integration/Services/EncyclopediaServiceTest.php
@@ -28,8 +28,8 @@ class EncyclopediaServiceTest extends TestCase
         $album = Album::factory()->create(['cover' => 'album-cover-for-thumbnail-test.jpg']);
 
         self::assertSame(
-            image_storage_url('album-cover-for-thumbnail-test_thumb.jpg'),
-            app(ImageStorage::class)->getAlbumThumbnailUrl($album)
+            'album-cover-for-thumbnail-test_thumb.jpg',
+            app(ImageStorage::class)->getOrCreateAlbumThumbnail($album)
         );
 
         self::assertFileExists(image_storage_path('album-cover-for-thumbnail-test_thumb.jpg'));
@@ -40,7 +40,7 @@ class EncyclopediaServiceTest extends TestCase
     {
         /** @var Album $album */
         $album = Album::factory()->create(['cover' => '']);
-        self::assertNull(app(ImageStorage::class)->getAlbumThumbnailUrl($album));
+        self::assertNull(app(ImageStorage::class)->getOrCreateAlbumThumbnail($album));
     }
 
     private function cleanUp(): void

--- a/tests/Integration/Services/PlaylistServiceTest.php
+++ b/tests/Integration/Services/PlaylistServiceTest.php
@@ -319,7 +319,7 @@ class PlaylistServiceTest extends TestCase
         $ulid = Ulid::freeze();
         $this->service->updatePlaylistCover($playlist, minimal_base64_encoded_image());
 
-        self::assertSame(image_storage_url("$ulid.webp"), $playlist->cover);
+        self::assertSame("$ulid.webp", $playlist->cover);
         self::assertFileExists(image_storage_path("$ulid.webp"));
         self::assertFileDoesNotExist(image_storage_path('foo.webp'));
     }

--- a/tests/Unit/Services/EncyclopediaServiceTest.php
+++ b/tests/Unit/Services/EncyclopediaServiceTest.php
@@ -72,7 +72,7 @@ class EncyclopediaServiceTest extends TestCase
         $album = Album::factory()->create(['cover' => '']);
         $info = AlbumInformation::make(cover: 'https://wiki.example.com/album-cover.jpg');
 
-        self::assertFalse($album->has_cover);
+        self::assertEmpty($album->cover);
 
         $this->encyclopedia
             ->expects('getAlbumInformation')
@@ -98,7 +98,7 @@ class EncyclopediaServiceTest extends TestCase
         $album = Album::factory()->create(['cover' => '']);
         $info = AlbumInformation::make(cover: 'https://wiki.example.com/album-cover.jpg');
 
-        self::assertFalse($album->has_cover);
+        self::assertEmpty($album->cover);
 
         $this->encyclopedia
             ->expects('getAlbumInformation')
@@ -121,7 +121,7 @@ class EncyclopediaServiceTest extends TestCase
         $artist = Artist::factory()->create();
         $info = ArtistInformation::make();
 
-        self::assertTrue($artist->has_image);
+        self::assertNotEmpty($artist->image);
 
         $this->encyclopedia
             ->expects('getArtistInformation')
@@ -139,7 +139,7 @@ class EncyclopediaServiceTest extends TestCase
         $artist = Artist::factory()->create(['image' => '']);
         $info = ArtistInformation::make(image: 'https://wiki.example.com/artist-image.jpg');
 
-        self::assertFalse($artist->has_image);
+        self::assertEmpty($artist->image);
 
         $this->encyclopedia
             ->expects('getArtistInformation')
@@ -165,7 +165,7 @@ class EncyclopediaServiceTest extends TestCase
         $artist = Artist::factory()->create(['image' => '']);
         $info = ArtistInformation::make(image: 'https://wiki.example.com/artist-image.jpg');
 
-        self::assertFalse($artist->has_image);
+        self::assertEmpty($artist->image);
 
         $this->encyclopedia
             ->expects('getArtistInformation')

--- a/tests/Unit/Services/ImageStorageTest.php
+++ b/tests/Unit/Services/ImageStorageTest.php
@@ -38,18 +38,16 @@ class ImageStorageTest extends TestCase
     {
         /** @var Album $album */
         $album = Album::factory()->create();
-        $coverPath = '/koel/public/img/album/foo.jpg';
+
+        Ulid::freeze('foo');
 
         $this->imageWriter
             ->expects('write')
-            ->with('/koel/public/img/album/foo.jpg', 'dummy-src');
+            ->with(image_storage_path('foo.webp'), 'dummy-src', null);
 
-        $this->imageWriter->expects('write');
+        $this->service->storeAlbumCover($album, 'dummy-src');
 
-        $cover = $this->service->storeAlbumCover($album, 'dummy-src', $coverPath);
-
-        self::assertSame(image_storage_url('foo.jpg'), $album->refresh()->cover);
-        self::assertSame($cover, $album->cover);
+        self::assertSame('foo.webp', $album->refresh()->cover);
     }
 
     #[Test]
@@ -57,15 +55,16 @@ class ImageStorageTest extends TestCase
     {
         /** @var Artist $artist */
         $artist = Artist::factory()->create();
-        $imagePath = '/koel/public/img/artist/foo.jpg';
+
+        Ulid::freeze('foo');
 
         $this->imageWriter
             ->expects('write')
-            ->with('/koel/public/img/artist/foo.jpg', 'dummy-src');
+            ->with(image_storage_path('foo.webp'), 'dummy-src', null);
 
-        $this->service->storeArtistImage($artist, 'dummy-src', $imagePath);
+        $this->service->storeArtistImage($artist, 'dummy-src');
 
-        self::assertSame(image_storage_url('foo.jpg'), $artist->refresh()->image);
+        self::assertSame('foo.webp', $artist->refresh()->image);
     }
 
     #[Test]


### PR DESCRIPTION
<!--
Thank you for contributing to Koel! Please provide a clear description of your changes below.
-->

## Description
Remove the "smart" URl and path attributes for image fields on artist, album, playlist, etc. Instead, use explicit functions (`image_storage_url()` and `image_storage_path()`) to turn the field values (file names) into URLs and paths only when necessary, e.g. in HTTP resources.

## Motivation
<!-- Explain why this change is necessary, e.g., if targeting an existing issue, link to it. -->

## Screenshots (if applicable)

## Checklist
- [x] I've tested my changes thoroughly and added tests where applicable
- [x] I've updated relevant documentation (if any)
- [x] My code follows the project's conventions
