### PR TITLE
chore: make file inputs not take the full width

### DIFF
--- a/resources/assets/js/components/profile-preferences/theme/CreateThemeForm.vue
+++ b/resources/assets/js/components/profile-preferences/theme/CreateThemeForm.vue
@@ -33,7 +33,7 @@
         </div>
 
         <label for="themeBgImage">Background image</label>
-        <div class="flex flex-col gap-2">
+        <div class="inline-flex flex-col gap-2">
           <span
             v-if="data.bg_image"
             class="w-36 aspect-video relative overflow-hidden rounded-md border border-k-fg-10"
@@ -47,10 +47,7 @@
               Remove
             </button>
           </span>
-          <span class="w-48">
-            <!-- wrap in a container so that the file input doesn't take up the whole width -->
-            <FileInput aria-label="Background image" accept="image/*" @change="onBackgroundImageChange" />
-          </span>
+          <FileInput aria-label="Background image" accept="image/*" @change="onBackgroundImageChange" />
         </div>
 
         <label>Font</label>

--- a/resources/assets/js/components/screens/settings/BrandingImageField.vue
+++ b/resources/assets/js/components/screens/settings/BrandingImageField.vue
@@ -1,6 +1,6 @@
 <template>
   <fieldset>
-    <h4>
+    <h4 class="text-k-fg">
       <slot name="label" />
     </h4>
 

--- a/resources/assets/js/components/ui/form/FileInput.vue
+++ b/resources/assets/js/components/ui/form/FileInput.vue
@@ -1,6 +1,6 @@
 <template>
   <label
-    class="flex text-base items-center gap-2 relative cursor-pointer hover:text-k-fg-70 active:text-k-fg-60"
+    class="inline-flex text-base items-center gap-2 relative cursor-pointer hover:text-k-fg-70 active:text-k-fg-60"
   >
     <input v-bind="$attrs" type="file" class="opacity-0 appearance-none absolute inset-0 z-10">
     <span class="border border-px border-white/20 px-1.5 py-1 rounded pointer-events-none">


### PR DESCRIPTION
<!--
Thank you for contributing to Koel! Please provide a clear description of your changes below.
-->

## Description
Make the file input take only the space needed.

## Motivation
Previous file inputs took the whole width of the container, causing annoying file dialog opens upon misclicks.

## Screenshots (if applicable)

## Checklist
- [x] I've tested my changes thoroughly and added tests where applicable
- [x] I've updated relevant documentation (if any)
- [x] My code follows the project's conventions