### PR TITLE
fix: enable picking custom themes when creating embeds

### DIFF
--- a/app/Http/Controllers/API/FetchInitialDataController.php
+++ b/app/Http/Controllers/API/FetchInitialDataController.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Resources\PlaylistFolderResource;
 use App\Http\Resources\PlaylistResource;
 use App\Http\Resources\QueueStateResource;
+use App\Http\Resources\ThemeResource;
 use App\Http\Resources\UserResource;
 use App\Models\Setting;
 use App\Models\User;
@@ -41,6 +42,9 @@ class FetchInitialDataController extends Controller
         Authenticatable $user
     ) {
         $licenseStatus = $licenseService->getStatus();
+        $theme = $licenseStatus->isValid()
+            ? $themeRepository->findUserThemeById($user->preferences->theme, $user)
+            : null;
 
         return response()->json([
             'settings' => $user->hasPermissionTo(Permission::MANAGE_SETTINGS)
@@ -78,9 +82,7 @@ class FetchInitialDataController extends Controller
             ],
             'storage_driver' => config('koel.storage_driver'),
             'dir_separator' => DIRECTORY_SEPARATOR,
-            'current_theme' => $licenseStatus->isValid()
-                ? $themeRepository->findUserThemeById($user->preferences->theme, $user)
-                : null,
+            'current_theme' => $theme ? ThemeResource::make($theme) : null,
         ]);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -109,7 +109,8 @@
       "@php artisan clear-compiled"
     ],
     "post-update-cmd": [
-      "@php artisan cache:clear"
+      "@php artisan cache:clear",
+      "@php artisan boost:update --ansi"
     ],
     "post-root-package-install": [
       "@php -r \"copy('.env.example', '.env');\""

--- a/resources/assets/js/components/embed/CreateEmbedForm.spec.ts
+++ b/resources/assets/js/components/embed/CreateEmbedForm.spec.ts
@@ -3,6 +3,7 @@ import { createHarness } from '@/__tests__/TestHarness'
 import { embedService } from '@/stores/embedService'
 import { screen, waitFor } from '@testing-library/vue'
 import Component from './CreateEmbedForm.vue'
+import { themeStore } from '@/stores/themeStore'
 
 describe('createEmbedForm.vue', () => {
   const h = createHarness()
@@ -73,6 +74,7 @@ describe('createEmbedForm.vue', () => {
 
   it('has a Theme dropdown for Plus user', async () => {
     await h.withPlusEdition(async () => {
+      h.mock(themeStore, 'fetchCustomThemes')
       const { embed, encryptOptionsMock } = await renderComponent()
 
       await h.user.click(screen.getByRole('checkbox', { name: 'Show code' }))
@@ -81,7 +83,11 @@ describe('createEmbedForm.vue', () => {
       screen.getByRole('combobox', { name: 'Layout' })
 
       encryptOptionsMock.mockResolvedValueOnce('encrypted-2')
-      await h.user.selectOptions(screen.getByRole('combobox', { name: 'Theme' }), 'laura')
+
+      // The Theme dropdown is loaded asynchronously, so we need to wait for it to be loaded and rendered
+      await waitFor(async () => {
+        await h.user.selectOptions(screen.getByRole('combobox', { name: 'Theme' }), 'laura')
+      })
 
       const iframe: HTMLIFrameElement = screen.getByTestId('embed-preview-iframe')
       expect(iframe.getAttribute('src')).toBe(`http://test/#/embed/${embed.id}/encrypted-2`)

--- a/resources/assets/js/components/embed/EmbedOptionsPanel.spec.ts
+++ b/resources/assets/js/components/embed/EmbedOptionsPanel.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { createHarness } from '@/__tests__/TestHarness'
+import Component from './EmbedOptionsPanel.vue'
+import { screen, waitFor } from '@testing-library/vue'
+
+describe('embedOptionsPanel.vue', () => {
+  const h = createHarness()
+
+  const renderComponent = () => {
+    return h.render(Component, {
+      props: {
+        modelValue: {
+          theme: 'classic',
+          layout: 'full',
+          preview: false,
+        } satisfies EmbedOptions,
+      },
+      global: {
+        stubs: {
+          ThemeSelectBox: h.stub('theme-select'),
+        },
+      },
+    })
+  }
+
+  it('does not have the theme option by default', () => {
+    renderComponent()
+    expect(screen.queryByTestId('theme-select')).toBeNull()
+  })
+
+  it('has the theme option in Plus edition', () => {
+    h.withPlusEdition(async () => {
+      renderComponent()
+      await waitFor(() => screen.getByTestId('theme-select'))
+    })
+  })
+})

--- a/resources/assets/js/components/embed/EmbedOptionsPanel.vue
+++ b/resources/assets/js/components/embed/EmbedOptionsPanel.vue
@@ -7,12 +7,7 @@
       </SelectBox>
     </FormRow>
 
-    <FormRow v-if="isPlus">
-      <template #label>Theme</template>
-      <SelectBox v-model="options.theme">
-        <option v-for="theme in themeStore.all" :key="theme.id" :value="theme.id">{{ theme.name }}</option>
-      </SelectBox>
-    </FormRow>
+    <ThemeSelectBox v-if="isPlus" v-model="options.theme" />
 
     <FormRow v-if="isPlus" class="col-span-2">
       <template #label>
@@ -26,13 +21,16 @@
 <script setup lang="ts">
 import { useKoelPlus } from '@/composables/useKoelPlus'
 import { toRefs } from 'vue'
-import { themeStore } from '@/stores/themeStore'
+import { defineAsyncComponent } from '@/utils/helpers'
 
 import FormRow from '@/components/ui/form/FormRow.vue'
 import SelectBox from '@/components/ui/form/SelectBox.vue'
 import CheckBox from '@/components/ui/form/CheckBox.vue'
 
 const props = defineProps<{ modelValue: EmbedOptions }>()
+
+const ThemeSelectBox = defineAsyncComponent(() => import('@/components/embed/ThemeSelectBox.vue'))
+
 const { modelValue: options } = toRefs(props)
 
 const { isPlus } = useKoelPlus()
@@ -42,7 +40,3 @@ const layouts: EmbedLayout[] = [
   { id: 'compact', name: 'Banner only' },
 ]
 </script>
-
-<style scoped lang="postcss">
-
-</style>

--- a/resources/assets/js/components/embed/ThemeSelectBox.spec.ts
+++ b/resources/assets/js/components/embed/ThemeSelectBox.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { createHarness } from '@/__tests__/TestHarness'
+import { themeStore } from '@/stores/themeStore'
+import { screen } from '@testing-library/vue'
+import Component from './ThemeSelectBox.vue'
+
+describe('themeSelectBox.vue', () => {
+  const h = createHarness()
+
+  it('fetches and renders the options', async () => {
+    const theme = h.factory('theme', {
+      id: 'frodo',
+      name: 'One Theme to Rule Them All',
+    })
+
+    const fetchThemesMock = h.mock(themeStore, 'fetchCustomThemes')
+
+    h.render(Component)
+
+    // since the mock overrides the actual implementation, we manually mutate the store
+    themeStore.state.themes.push(theme)
+
+    await h.tick()
+
+    expect(fetchThemesMock).toHaveBeenCalled()
+    await h.user.selectOptions(screen.getByRole('combobox'), ['frodo'])
+  })
+})

--- a/resources/assets/js/components/embed/ThemeSelectBox.vue
+++ b/resources/assets/js/components/embed/ThemeSelectBox.vue
@@ -1,0 +1,25 @@
+<template>
+  <FormRow>
+    <template #label>Theme</template>
+    <SelectBox v-model="model">
+      <option v-for="theme in themes" :key="theme.id" :value="theme.id">{{ theme.name }}</option>
+    </SelectBox>
+  </FormRow>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { themeStore } from '@/stores/themeStore'
+
+import SelectBox from '@/components/ui/form/SelectBox.vue'
+import FormRow from '@/components/ui/form/FormRow.vue'
+
+const model = defineModel<Theme>()
+
+const themes = ref<Theme[]>([])
+
+onMounted(async () => {
+  await themeStore.fetchCustomThemes()
+  themes.value = themeStore.all
+})
+</script>

--- a/resources/assets/js/components/embed/widget/EmbedWidget.vue
+++ b/resources/assets/js/components/embed/widget/EmbedWidget.vue
@@ -71,7 +71,8 @@ const getPayload = async (id: string, encryptedOptions: string) => {
     options.value = payload.options
     embed.value = payload.embed
 
-    themeStore.init(options.value.theme)
+    // if the payload's theme is null, the theme is not custom. Resort to the built-in themes.
+    themeStore.init(payload.theme || options.value.theme)
   } catch (e: unknown) {
     error.value = e
     return

--- a/resources/assets/js/components/embed/widget/audio-player/EmbedAudioPlayerPlayButton.vue
+++ b/resources/assets/js/components/embed/widget/audio-player/EmbedAudioPlayerPlayButton.vue
@@ -5,7 +5,7 @@
     data-testid="wrapper"
   >
     <button
-      class="w-12 aspect-square rounded-full text-k-highlight-fg bg-k-highlight border border-px border-k-highlight"
+      class="w-12 aspect-square rounded-full text-k-highlight-fg bg-k-highlight border border-k-bg"
       type="button"
       @click.prevent="emit('clicked')"
     >
@@ -36,7 +36,7 @@ const playing = computed(() => playable.value?.playback_state === 'Playing')
 
 <style lang="postcss" scoped>
 .preview-wrapper {
-  --bg-color: rgba(255, 255, 255, 0.7);
+  --bg-color: color-mix(in srgb, var(--color-highlight), transparent 60%);
 
   background-size: 100% 100%;
   background-position: 0 0;

--- a/resources/assets/js/stores/embedService.ts
+++ b/resources/assets/js/stores/embedService.ts
@@ -24,7 +24,7 @@ export const embedService = {
   },
 
   async getWidgetPayload (id: string, encryptedOptions: string) {
-    const payload = await http.get<{ embed: WidgetReadyEmbed, options: EmbedOptions }>(
+    const payload = await http.get<{ embed: WidgetReadyEmbed, options: EmbedOptions, theme: Theme | null }>(
       `embeds/${id}/${encryptedOptions}`,
     )
 

--- a/tests/Feature/EmbedTest.php
+++ b/tests/Feature/EmbedTest.php
@@ -44,6 +44,7 @@ class EmbedTest extends TestCase
         $jsonStructure = [
             'embed' => EmbedResource::JSON_PUBLIC_STRUCTURE,
             'options' => EmbedOptionsResource::JSON_STRUCTURE,
+            'theme',
         ];
 
         /** @var Embed $embed */

--- a/tests/Feature/KoelPlus/EmbedTest.php
+++ b/tests/Feature/KoelPlus/EmbedTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature\KoelPlus;
+
+use App\Http\Resources\EmbedOptionsResource;
+use App\Http\Resources\EmbedResource;
+use App\Http\Resources\ThemeResource;
+use App\Models\Embed;
+use App\Models\Theme;
+use App\Values\EmbedOptions;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\PlusTestCase;
+
+class EmbedTest extends PlusTestCase
+{
+    #[Test]
+    public function getPayloadWithCustomTheme(): void
+    {
+        /** @var Theme $theme */
+        $theme = Theme::factory()->create();
+
+        $jsonStructure = [
+            'embed' => EmbedResource::JSON_PUBLIC_STRUCTURE,
+            'options' => EmbedOptionsResource::JSON_STRUCTURE,
+            'theme' => ThemeResource::JSON_STRUCTURE,
+        ];
+
+        /** @var Embed $embed */
+        $embed = Embed::factory()->create();
+        $options = EmbedOptions::make(theme: $theme->id);
+
+        $this->getAs("api/embeds/{$embed->id}/$options")
+            ->assertSuccessful()
+            ->assertJsonStructure($jsonStructure);
+
+        // getJson() instead of getAs() to make sure it passes without authentication
+        $this->getJson("api/embeds/{$embed->id}/$options")
+            ->assertSuccessful()
+            ->assertJsonStructure($jsonStructure);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Koel! Please provide a clear description of your changes below.
-->

## Description
Add custom themes to the theme selection when creating embeds.

## Motivation
<!-- Explain why this change is necessary, e.g., if targeting an existing issue, link to it. -->

## Screenshots (if applicable)

## Checklist
- [x] I've tested my changes thoroughly and added tests where applicable
- [x] I've updated relevant documentation (if any)
- [x] My code follows the project's conventions
