### PR TITLE
feat(ui): use dialog element for context menus

### DIFF
--- a/resources/assets/js/components/ui/context-menu/ContextMenu.vue
+++ b/resources/assets/js/components/ui/context-menu/ContextMenu.vue
@@ -1,17 +1,17 @@
 <template>
-  <nav
-    v-if="shown"
+  <dialog
     ref="el"
     v-koel-focus
     :class="extraClass"
     :style="{ top, left, bottom, right }"
-    class="menu context-menu select-none shadow"
+    class="menu context-menu select-none shadow overflow-visible backdrop:opacity-0"
     tabindex="0"
+    @mousedown="onMouseDown"
     @contextmenu.prevent
     @keydown.esc="close"
   >
     <component :is="options.component" v-if="options.component" v-bind="options.props" />
-  </nav>
+  </dialog>
 </template>
 
 <script lang="ts" setup>
@@ -26,8 +26,7 @@ const { extraClass } = toRefs(props)
 
 const options = requireInjection(ContextMenuKey)
 
-const el = ref<HTMLElement>()
-const shown = ref(false)
+const el = ref<HTMLDialogElement>()
 const top = ref('0')
 const left = ref('0')
 const bottom = ref('auto')
@@ -101,7 +100,7 @@ const open = async (t = 0, l = 0) => {
   left.value = `${l}px`
   bottom.value = 'auto'
   right.value = 'auto'
-  shown.value = true
+  el.value?.showModal()
 
   await nextTick()
 
@@ -118,13 +117,14 @@ const open = async (t = 0, l = 0) => {
   }, 100)
 }
 
-const close = () => {
-  shown.value = false
-}
+const close = () => el.value?.close()
 
-watch(options, () => {
-  if (options.value.component) {
-    open(options.value.position.top, options.value.position.left)
+// Close the context menu when clicking outside it.
+const onMouseDown = (e: MouseEvent) => e.target === el.value && close()
+
+watch(options, newOptions => {
+  if (newOptions.component) {
+    open(newOptions.position.top, newOptions.position.left)
   } else {
     close()
   }


### PR DESCRIPTION
<!--
Thank you for contributing to Koel! Please provide a clear description of your changes below.
-->

## Description
Use the `<dialog>` element for context menus, ensuring it always appears on top of other layers (and even other top-layer elements).

## Motivation
<!-- Explain why this change is necessary, e.g., if targeting an existing issue, link to it. -->

## Screenshots (if applicable)

## Checklist
- [x] I've tested my changes thoroughly and added tests where applicable
- [x] I've updated relevant documentation (if any)
- [x] My code follows the project's conventions
