### PR TITLE
fix: allow empty radio description

### DIFF
--- a/app/Http/Requests/API/Radio/RadioStationStoreRequest.php
+++ b/app/Http/Requests/API/Radio/RadioStationStoreRequest.php
@@ -41,7 +41,7 @@ class RadioStationStoreRequest extends Request
         return RadioStationCreateData::make(
             url: $this->url,
             name: $this->name,
-            description: $this->description,
+            description: (string) $this->description,
             logo: $this->logo,
             isPublic: $this->is_public,
         );

--- a/app/Http/Requests/API/Radio/RadioStationUpdateRequest.php
+++ b/app/Http/Requests/API/Radio/RadioStationUpdateRequest.php
@@ -31,7 +31,7 @@ class RadioStationUpdateRequest extends Request
             ],
             'name' => ['required', 'string', 'max:191'],
             'logo' => ['nullable', new ValidImageData()],
-            'description' => ['string'],
+            'description' => ['string', 'nullable'],
             'is_public' => ['boolean'],
         ];
     }
@@ -41,7 +41,7 @@ class RadioStationUpdateRequest extends Request
         return RadioStationUpdateData::make(
             name: $this->name,
             url: $this->url,
-            description: $this->description,
+            description: (string) $this->description,
             logo: $this->logo,
             isPublic: $this->boolean('is_public')
         );

--- a/tests/Feature/RadioStationTest.php
+++ b/tests/Feature/RadioStationTest.php
@@ -59,6 +59,29 @@ class RadioStationTest extends TestCase
     }
 
     #[Test]
+    public function createStationWithEmptyDescription(): void
+    {
+        $user = create_user();
+        $this->postAs('/api/radio/stations', [
+            'url' => 'https://example.com/stream',
+            'name' => 'Test Radio Station',
+            'description' => '',
+            'is_public' => false,
+        ], $user)
+            ->assertCreated()
+            ->assertJsonStructure(RadioStationResource::JSON_STRUCTURE);
+
+        $this->assertDatabaseHas(RadioStation::class, [
+            'url' => 'https://example.com/stream',
+            'name' => 'Test Radio Station',
+            'logo' => null,
+            'description' => '',
+            'is_public' => false,
+            'user_id' => $user->id,
+        ]);
+    }
+
+    #[Test]
     public function updateStation(): void
     {
         $this->imageStorage->shouldNotReceive('storeImage');
@@ -84,6 +107,33 @@ class RadioStationTest extends TestCase
             'logo' => $logo, // logo should remain unchanged
             'description' => 'An updated test radio station',
             'is_public' => false,
+        ]);
+    }
+
+    #[Test]
+    public function updateStationWithEmptyDescription(): void
+    {
+        /** @var RadioStation $station */
+        $station = RadioStation::factory()->create();
+        $logo = $station->getRawOriginal('logo');
+
+        $this->putAs("/api/radio/stations/{$station->id}", [
+            'url' => 'https://example.com/updated-stream',
+            'name' => 'Updated Radio Station',
+            'logo' => null,
+            'description' => '',
+            'is_public' => true,
+        ], $station->user)
+            ->assertOk()
+            ->assertJsonStructure(RadioStationResource::JSON_STRUCTURE);
+
+        $this->assertDatabaseHas(RadioStation::class, [
+            'id' => $station->id,
+            'url' => 'https://example.com/updated-stream',
+            'name' => 'Updated Radio Station',
+            'logo' => $logo,
+            'description' => '',
+            'is_public' => true,
         ]);
     }
 


### PR DESCRIPTION
## Description
Allows radio description to be empty. 

## Motivation
It's the same as in https://github.com/koel/koel/pull/2118 

## Checklist
- [ ✅ ] I've tested my changes thoroughly and added tests where applicable
- [ ✅] I've updated relevant documentation (if any)
- [ ✅ ] My code follows the project's conventions
