### PR TITLE
feat: delete podcast upon last unsubscription

### DIFF
--- a/app/Events/UserUnsubscribedFromPodcast.php
+++ b/app/Events/UserUnsubscribedFromPodcast.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Podcast;
+use App\Models\User;
+
+class UserUnsubscribedFromPodcast extends Event
+{
+    public function __construct(public readonly User $user, public readonly Podcast $podcast)
+    {
+    }
+}

--- a/app/Listeners/DeletePodcastIfNoSubscribers.php
+++ b/app/Listeners/DeletePodcastIfNoSubscribers.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\UserUnsubscribedFromPodcast;
+use App\Services\PodcastService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+readonly class DeletePodcastIfNoSubscribers implements ShouldQueue
+{
+    public function __construct(private PodcastService $podcastService)
+    {
+    }
+
+    public function handle(UserUnsubscribedFromPodcast $event): void
+    {
+        if ($event->podcast->subscribers()->count() === 0) {
+            $this->podcastService->deletePodcast($event->podcast);
+        }
+    }
+}

--- a/app/Listeners/WriteScanLog.php
+++ b/app/Listeners/WriteScanLog.php
@@ -8,7 +8,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\File;
 
-class WriteScanLog implements ShouldQueue
+readonly class WriteScanLog implements ShouldQueue
 {
     public function handle(MediaScanCompleted $event): void
     {

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -9,7 +9,9 @@ use App\Events\MultipleSongsUnliked;
 use App\Events\NewPlaylistCollaboratorJoined;
 use App\Events\PlaybackStarted;
 use App\Events\SongFavoriteToggled;
+use App\Events\UserUnsubscribedFromPodcast;
 use App\Listeners\DeleteNonExistingRecordsPostScan;
+use App\Listeners\DeletePodcastIfNoSubscribers;
 use App\Listeners\LoveMultipleTracksOnLastfm;
 use App\Listeners\LoveTrackOnLastfm;
 use App\Listeners\MakePlaylistSongsPublic;
@@ -68,6 +70,10 @@ class EventServiceProvider extends BaseServiceProvider
 
         NewPlaylistCollaboratorJoined::class => [
             MakePlaylistSongsPublic::class,
+        ],
+
+        UserUnsubscribedFromPodcast::class => [
+            DeletePodcastIfNoSubscribers::class,
         ],
     ];
 

--- a/tests/Unit/Listeners/DeletePodcastIfNoSubscribersTest.php
+++ b/tests/Unit/Listeners/DeletePodcastIfNoSubscribersTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Unit\Listeners;
+
+use App\Events\UserUnsubscribedFromPodcast;
+use App\Listeners\DeletePodcastIfNoSubscribers;
+use App\Models\Podcast;
+use App\Services\PodcastService;
+use Mockery;
+use Mockery\MockInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+use function Tests\create_user;
+
+class DeletePodcastIfNoSubscribersTest extends TestCase
+{
+    private MockInterface|PodcastService $podcastService;
+    private DeletePodcastIfNoSubscribers $listener;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->podcastService = Mockery::mock(PodcastService::class);
+        $this->listener = new DeletePodcastIfNoSubscribers($this->podcastService);
+    }
+
+    #[Test]
+    public function handlePodcastWithNoSubscribers(): void
+    {
+        /** @var Podcast $podcast */
+        $podcast = Podcast::factory()->create();
+
+        $this->podcastService->expects('deletePodcast')->once()->with($podcast);
+
+        $this->listener->handle(new UserUnsubscribedFromPodcast(create_user(), $podcast));
+    }
+
+    #[Test]
+    public function handlePodcastWithSubscribers(): void
+    {
+        /** @var Podcast $podcast */
+        $podcast = Podcast::factory()->create();
+        $podcast->subscribers()->attach(create_user());
+
+        $this->podcastService->expects('deletePodcast')->never();
+
+        $this->listener->handle(new UserUnsubscribedFromPodcast(create_user(), $podcast));
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Koel! Please provide a clear description of your changes below.
-->

## Description
Dispatch an event to delete a podcast if it doesn't have any subscribers.

## Motivation
In the past, unsubscribing a user simply "detached" them from a podcast, when the podcast itself remained in the database. The reason was two-fold:

- A podcast can be subscribed to by multiple users in the system.
- To save resources, as podcast operations can be resource-sensitive. 

However, for installations that have only one user, this approach has been creating confusion: the single user expects the podcast data to be removed and is surprised to see it's not.

## Screenshots (if applicable)

## Checklist
- [x] I've tested my changes thoroughly and added tests where applicable
- [x] I've updated relevant documentation (if any)
- [x] My code follows the project's conventions
