### PR TITLE
Fix S3 key derivation

### DIFF
--- a/app/Models/Song.php
+++ b/app/Models/Song.php
@@ -18,7 +18,6 @@ use App\Values\Scanning\ScanInformation;
 use App\Values\SongStorageMetadata\DropboxMetadata;
 use App\Values\SongStorageMetadata\LocalMetadata;
 use App\Values\SongStorageMetadata\S3CompatibleMetadata;
-use App\Values\SongStorageMetadata\S3LambdaMetadata;
 use App\Values\SongStorageMetadata\SftpMetadata;
 use App\Values\SongStorageMetadata\SongStorageMetadata;
 use Carbon\Carbon;

--- a/app/Values/SongStorageMetadata/S3LambdaMetadata.php
+++ b/app/Values/SongStorageMetadata/S3LambdaMetadata.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace App\Values\SongStorageMetadata;
-
-final class S3LambdaMetadata extends S3CompatibleMetadata
-{
-}


### PR DESCRIPTION
<!--
Thank you for contributing to Koel! Please provide a clear description of your changes below.
-->

## Description
Koel presently derives s3cs URLs incorrectly: when translating an `s3://bucket/key/for/object` URI to a signed URL, it effectively uses the last segment of the key as the the entire object key. For instance, given the aforementioned example URI, the generated download URL is `https://bucket.{endpoint}/object` when it should be `https://bucket.{endpoint}/key/for/object`. 

This happens because of match greediness: as both capture groups contain zero-or-more wildcard (`.`) matches, the regex will only fill the second group as much as is necessary to satisfy a complete match, which places a `/` between the groups.

## Motivation
Koel is in theory easier to use with preexisting object stores than Funkwhale, and this is essentially the only blocking issue.

## Screenshots (if applicable)

## Checklist
- [x] I've tested my changes thoroughly and added tests where applicable
- [ ] I've updated relevant documentation (if any)
- [ ] My code follows the project's conventions
