### PR TITLE
feat: row number in lists

### DIFF
--- a/resources/assets/js/components/playable/playable-list/PlayableList.vue
+++ b/resources/assets/js/components/playable/playable-list/PlayableList.vue
@@ -11,13 +11,14 @@
     <PlayableListHeader v-if="config.hasHeader" :content-type="contentType" @sort="sort" />
 
     <VirtualScroller
-      v-slot="{ item }: { item: PlayableRow }"
+      v-slot="{ item, index }: { item: PlayableRow, index: number }"
       :item-height="calculatedItemHeight"
       :items="rows"
       @scrolled-to-end="$emit('scrolled-to-end')"
     >
       <PlayableListItem
         :key="item.playable.id"
+        :index="index"
         :item="item"
         :show-disc="showDiscLabel(item.playable)"
         draggable="true"
@@ -327,8 +328,13 @@ onMounted(() => render())
       @apply basis-20 overflow-visible;
     }
 
-    &.track-number {
+    &.track-number,
+    &.table-row-number {
       @apply basis-16;
+
+      &.large {
+        @apply basis-24;
+      }
     }
 
     &.album {
@@ -396,8 +402,8 @@ onMounted(() => render())
       width: 200%;
     }
 
-    .song-item :is(.track-number, .album, .time, .year, .genre, .added-at),
-    .song-list-header :is(.track-number, .album, .time, .year, .genre, .added-at) {
+    .song-item :is(.table-row-number, .track-number, .album, .time, .year, .genre, .added-at),
+    .song-list-header :is(.table-row-number, .track-number, .album, .time, .year, .genre, .added-at) {
       display: none;
     }
 

--- a/resources/assets/js/components/playable/playable-list/PlayableListHeader.vue
+++ b/resources/assets/js/components/playable/playable-list/PlayableListHeader.vue
@@ -4,17 +4,37 @@
     class="song-list-header flex z-[2] bg-k-fg-3 pl-5"
   >
     <span
+      v-if="shouldShowColumn('tableRow')"
+      class="table-row-number"
+      data-testid="header-table-row-number"
+    >
+      #
+    </span>
+    <span
       v-if="shouldShowColumn('track')"
-      class="track-number"
+      :class="`track-number${shouldShowColumn('tableRow') ? ' large' : ''}`"
       data-testid="header-track-number"
       role="button"
       title="Sort by track number"
       @click="sort('track')"
     >
-      #
+      {{ shouldShowColumn('tableRow') ? 'Track #' : '#' }}
       <template v-if="config.sortable">
         <Icon v-if="sortField === 'track' && sortOrder === 'asc'" :icon="faCaretUp" class="text-k-highlight" />
         <Icon v-if="sortField === 'track' && sortOrder === 'desc'" :icon="faCaretDown" class="text-k-highlight" />
+      </template>
+    </span>
+    <span
+      class="title-artist"
+      data-testid="header-title"
+      role="button"
+      title="Sort by title"
+      @click="sort('title')"
+    >
+      Title
+      <template v-if="config.sortable">
+        <Icon v-if="sortField === 'title' && sortOrder === 'asc'" :icon="faCaretUp" class="text-k-highlight" />
+        <Icon v-if="sortField === 'title' && sortOrder === 'desc'" :icon="faCaretDown" class="text-k-highlight" />
       </template>
     </span>
     <span

--- a/resources/assets/js/components/playable/playable-list/PlayableListHeaderActionMenu.vue
+++ b/resources/assets/js/components/playable/playable-list/PlayableListHeaderActionMenu.vue
@@ -9,9 +9,9 @@
         <li
           v-for="item in menuItems"
           :key="item.label"
-          :class="currentlySortedBy(item.field) && 'active'"
+          :class="(item.sortable === undefined || item.sortable) && currentlySortedBy(item.field) && 'active'"
           class="cursor-pointer group flex justify-between !pl-3 hover:!bg-k-highlight hover:!text-k-highlight-fg"
-          @click="sortable && sort(item.field)"
+          @click="sortable && (item.sortable === undefined || item.sortable) && sort(item.field)"
         >
           <label
             v-if="shouldShowColumnVisibilityCheckboxes()"
@@ -70,6 +70,7 @@ interface MenuItem {
   label: string
   field: MaybeArray<PlayableListSortField>
   visibilityToggleable: boolean
+  sortable?: boolean
 }
 
 const {
@@ -84,6 +85,8 @@ const button = ref<HTMLButtonElement>()
 const menu = ref<HTMLDivElement>()
 
 const menuItems = computed(() => {
+  const tableRow: MenuItem = { column: 'tableRow', label: 'Table Row', field: 'title', visibilityToggleable: true, sortable: false }
+
   const title: MenuItem = { column: 'title', label: 'Title', field: 'title', visibilityToggleable: false }
   const artist: MenuItem = { label: 'Artist', field: 'artist_name', visibilityToggleable: false }
   const author: MenuItem = { label: 'Author', field: 'podcast_author', visibilityToggleable: false }
@@ -117,12 +120,12 @@ const menuItems = computed(() => {
 
   const customOrder: MenuItem = { label: 'Custom Order', field: 'position', visibilityToggleable: false }
 
-  let items: MenuItem[] = [title, album, artist, track, genre, year, time, dateAdded]
+  let items: MenuItem[] = [tableRow, title, album, artist, track, genre, year, time, dateAdded]
 
   if (contentType.value === 'episodes') {
-    items = [title, podcast, author, time, dateAdded]
+    items = [tableRow, title, podcast, author, time, dateAdded]
   } else if (contentType.value === 'mixed') {
-    items = [title, albumOrPodcast, artistOrAuthor, time, dateAdded]
+    items = [tableRow, title, albumOrPodcast, artistOrAuthor, time, dateAdded]
   }
 
   if (hasCustomOrderSort.value) {

--- a/resources/assets/js/components/playable/playable-list/PlayableListItem.vue
+++ b/resources/assets/js/components/playable/playable-list/PlayableListItem.vue
@@ -14,16 +14,22 @@
       tabindex="0"
       @dblclick.prevent.stop="play"
     >
-      <span v-if="shouldShowColumn('track')" class="track-number">
+      <span v-if="shouldShowColumn('tableRow')" class="table-row-number">
+        {{ props.index + 1 }}
+      </span>
+
+      <span v-if="shouldShowColumn('track')" :class="`track-number${shouldShowColumn('tableRow') ? ' large' : ''}`">
         <SoundBars v-if="playable.playback_state === 'Playing'" />
         <span v-else>
           <template v-if="isSong(playable)">{{ playable.track || '' }}</template>
           <Icon v-else :icon="faPodcast" />
         </span>
       </span>
+
       <span class="thumbnail leading-none">
         <PlayableThumbnail :playable @clicked="play" />
       </span>
+
       <span class="title-artist flex flex-col gap-2 overflow-hidden">
         <span class="title text-k-fg !flex gap-2 items-center">
           <ExternalMark v-if="external" />
@@ -31,7 +37,9 @@
         </span>
         <span class="artist">{{ artist }}</span>
       </span>
+
       <span v-if="shouldShowColumn('album')" class="album">{{ album }}</span>
+
       <template v-if="config.collaborative && isSong(playable) && playable.collaboration">
         <span class="collaborator">
           <UserAvatar :user="collaborator" width="24" />
@@ -40,11 +48,14 @@
           {{ playable.collaboration.fmt_added_at }}
         </span>
       </template>
+
       <template v-if="isSong(playable)">
         <span v-if="shouldShowColumn('genre')" class="genre">{{ playable.genre || '—' }}</span>
         <span v-if="shouldShowColumn('year')" class="year">{{ playable.year || '—' }}</span>
       </template>
+
       <span v-if="shouldShowColumn('duration')" class="time font-mono">{{ fmtLength }}</span>
+
       <span class="extra">
         <FavoriteButton :favorite="playable.favorite" @toggle="toggleFavorite" />
       </span>
@@ -68,7 +79,7 @@ import UserAvatar from '@/components/user/UserAvatar.vue'
 import ExternalMark from '@/components/ui/ExternalMark.vue'
 import FavoriteButton from '@/components/ui/FavoriteButton.vue'
 
-const props = withDefaults(defineProps<{ item: PlayableRow, showDisc?: boolean }>(), {
+const props = withDefaults(defineProps<{ item: PlayableRow, index: number, showDisc?: boolean }>(), {
   showDisc: false,
 })
 

--- a/resources/assets/js/components/ui/VirtualScroller.vue
+++ b/resources/assets/js/components/ui/VirtualScroller.vue
@@ -7,7 +7,7 @@
   >
     <div :style="{ height: `${totalHeight}px` }" class="will-change-transform overflow-hidden">
       <div :style="{ transform: `translateY(${offsetY}px)` }" class="will-change-transform items-wrapper">
-        <slot v-for="item in renderedItems" :item="item" />
+        <slot v-for="(item, itemIndex) in renderedItems" :item="item" :index="startPosition + itemIndex" />
       </div>
     </div>
   </div>

--- a/resources/assets/js/composables/usePlayableListColumnVisibility.ts
+++ b/resources/assets/js/composables/usePlayableListColumnVisibility.ts
@@ -9,6 +9,7 @@ const visibleColumns: Ref<PlayableListColumnName[]> = ref([])
 export const usePlayableListColumnVisibility = () => {
   const collectVisibleColumns = () => {
     const validColumns: PlayableListColumnName[] = [
+      'tableRow',
       'track',
       'genre',
       'year',

--- a/resources/assets/js/types.d.ts
+++ b/resources/assets/js/types.d.ts
@@ -611,7 +611,8 @@ interface Visualizer {
 }
 
 type PlayableListColumnName =
-  'title'
+  'tableRow'
+  | 'title'
   | 'album'
   | 'artist'
   | 'track'


### PR DESCRIPTION
## Description
This PR adds a way to see the row number in lists (mainly used for playlists).

Note that I did not do any tests as I have no clue how to do this on the frontend.

I made sure to change the "Track number" header only if the table row number is enabled to not disrupt the current users.

## Motivation
I'm currently in the process of trying to switch from Spotify to Koel, and I much prefer having the row number instead of the track in the first column, as most of the time I do not care about the actual track number.

This is the default in most software such as Spotify / Deezer / ... so I think its a good idea to have it, even if the default is not enabled.

## Screenshots (if applicable)
<img width="441" height="617" alt="1765480795" src="https://github.com/user-attachments/assets/e55f6c2d-4431-46e2-8fdb-a293f0370b27" />

## Checklist
- [ ] I've tested my changes thoroughly and added tests where applicable
- [x] I've updated relevant documentation (if any)
- [x] My code follows the project's conventions
