### PR TITLE
Fix missing lyrics support for FLAC files

### DIFF
--- a/app/Values/Scanning/ScanInformation.php
+++ b/app/Values/Scanning/ScanInformation.php
@@ -38,6 +38,7 @@ class ScanInformation implements Arrayable
             Arr::get($info, 'tags.id3v1', []),
             Arr::get($info, 'tags.id3v2', []),
             Arr::get($info, 'comments', []),
+            Arr::get($info, 'tags.vorbiscomment', []),
         );
 
         $comments = Arr::get($info, 'comments', []);
@@ -60,6 +61,7 @@ class ScanInformation implements Arrayable
             'unsynchronised_lyric',
             'unsychronised_lyric',
             'unsyncedlyrics',
+            'lyrics',
         ]));
 
         return new self(


### PR DESCRIPTION
### Summary
This PR fixes an issue where lyrics embedded in FLAC files were not being detected by the scanner.

### Technical Details
The scanner was primarily targeting ID3 tags (used in MP3s), but FLAC files use Vorbis Comments for metadata.
1. The `tags.vorbiscomment` array returned by `getID3` was previously excluded during the tag merge process.
2. The standard Vorbis comment key for lyrics is simply `LYRICS`, which was missing from the lookup list (unlike ID3's `unsynchronised_lyric`).

### Changes
* **Modified `ScanInformation.php`**:
    * Included `tags.vorbiscomment` in the `array_merge` logic to expose native FLAC tags.
    * Added `'lyrics'` to the priority list when extracting lyric data.

### Fixes
Fixes #2176