### PR TITLE
fix: do not use model factories for doctor command

### DIFF
--- a/app/Console/Commands/DoctorCommand.php
+++ b/app/Console/Commands/DoctorCommand.php
@@ -11,7 +11,6 @@ use App\Http\Integrations\Lastfm\Requests\GetArtistInfoRequest;
 use App\Http\Integrations\Spotify\SpotifyClient;
 use App\Http\Integrations\YouTube\Requests\SearchVideosRequest;
 use App\Http\Integrations\YouTube\YouTubeConnector;
-use App\Models\Artist;
 use App\Models\Setting;
 use App\Models\Song;
 use App\Models\User;
@@ -166,11 +165,8 @@ class DoctorCommand extends Command
             /** @var LastfmConnector $connector */
             $connector = app(LastfmConnector::class);
 
-            /** @var Artist $artist */
-            $artist = Artist::factory()->make(['name' => 'Pink Floyd']);
-
             try {
-                $dto = $connector->send(new GetArtistInfoRequest($artist))->dto();
+                $dto = $connector->send(new GetArtistInfoRequest('Pink Floyd'))->dto();
 
                 if (!$dto) {
                     throw new Exception('No data returned.');
@@ -189,11 +185,8 @@ class DoctorCommand extends Command
             /** @var YouTubeConnector $connector */
             $connector = app(YouTubeConnector::class);
 
-            /** @var Song $artist */
-            $song = Song::factory()->forArtist(['name' => 'Pink Floyd'])->make(['title' => 'Comfortably Numb']); // @phpstan-ignore-line
-
             try {
-                $object = $connector->send(new SearchVideosRequest($song))->object();
+                $object = $connector->send(new SearchVideosRequest('Pink Floyd Comfortably Numb'))->object();
 
                 if (object_get($object, 'error')) {
                     throw new Exception(object_get($object, 'error.message'));
@@ -214,13 +207,7 @@ class DoctorCommand extends Command
             Cache::forget(SpotifyClient::ACCESS_TOKEN_CACHE_KEY);
 
             try {
-                /** @var Artist $artist */
-                $artist = Artist::factory()->make([
-                    'id' => 999,
-                    'name' => 'Pink Floyd',
-                ]);
-
-                $image = $service->tryGetArtistImage($artist);
+                $image = $service->tryGetArtistImage('Pink Floyd');
 
                 if (!$image) {
                     throw new Exception('No result returned.');

--- a/app/Http/Integrations/Lastfm/Requests/GetArtistInfoRequest.php
+++ b/app/Http/Integrations/Lastfm/Requests/GetArtistInfoRequest.php
@@ -15,7 +15,7 @@ final class GetArtistInfoRequest extends Request
 
     protected Method $method = Method::GET;
 
-    public function __construct(private readonly Artist $artist)
+    public function __construct(private readonly Artist|string $artist)
     {
     }
 
@@ -29,7 +29,7 @@ final class GetArtistInfoRequest extends Request
     {
         return [
             'method' => 'artist.getInfo',
-            'artist' => $this->artist->name,
+            'artist' => $this->artist instanceof Artist ? $this->artist->name : $this->artist,
             'autocorrect' => 1,
             'format' => 'json',
         ];

--- a/app/Http/Integrations/YouTube/Requests/SearchVideosRequest.php
+++ b/app/Http/Integrations/YouTube/Requests/SearchVideosRequest.php
@@ -10,7 +10,7 @@ class SearchVideosRequest extends Request
 {
     protected Method $method = Method::GET;
 
-    public function __construct(private readonly Song $song, private readonly string $pageToken = '')
+    public function __construct(private readonly Song|string $song, private readonly string $pageToken = '')
     {
     }
 
@@ -22,11 +22,15 @@ class SearchVideosRequest extends Request
     /** @inheritdoc */
     protected function defaultQuery(): array
     {
-        $q = $this->song->title;
+        if ($this->song instanceof Song) {
+            $q = $this->song->title;
 
-        // If the artist is worth noticing, include them into the search.
-        if (!$this->song->artist->is_unknown && !$this->song->artist->is_various) {
-            $q .= " {$this->song->artist->name}";
+            // If the artist is worth noticing, include them into the search.
+            if (!$this->song->artist->is_unknown && !$this->song->artist->is_various) {
+                $q .= " {$this->song->artist->name}";
+            }
+        } else {
+            $q = $this->song;
         }
 
         return [

--- a/app/Models/Artist.php
+++ b/app/Models/Artist.php
@@ -30,7 +30,7 @@ use OwenIt\Auditing\Contracts\Auditable as AuditableContract;
  * @property Collection<array-key, Song> $songs
  * @property User $user
  * @property bool $is_unknown If the artist is Unknown Artist
- * @property bool $is_various If the artist is Various Artist
+ * @property bool $is_various If the artist is Various Artists
  * @property int $user_id The ID of the user that owns this artist
  * @property string $id
  * @property string $name

--- a/app/Services/SpotifyService.php
+++ b/app/Services/SpotifyService.php
@@ -18,18 +18,18 @@ class SpotifyService
         return config('koel.services.spotify.client_id') && config('koel.services.spotify.client_secret');
     }
 
-    public function tryGetArtistImage(Artist $artist): ?string
+    public function tryGetArtistImage(Artist|string $artist): ?string
     {
         if (!static::enabled()) {
             return null;
         }
 
-        if ($artist->is_various || $artist->is_unknown) {
+        if ($artist instanceof Artist && ($artist->is_various || $artist->is_unknown)) {
             return null;
         }
 
         return Arr::get(
-            $this->client->search($artist->name, 'artist', ['limit' => 1]),
+            $this->client->search($artist instanceof Artist ? $artist->name : $artist, 'artist', ['limit' => 1]),
             'artists.items.0.images.0.url'
         );
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Koel! Please provide a clear description of your changes below.
-->

## Description
Update `koel:doctor` and relevant service methods to not require and use model factories during the command.

## Motivation
Though not reproducible, apparently `koel:doctor` can trigger implicit user creation via the use of model factories. Removing the need for model factories in the command should fix the issue.

## Screenshots (if applicable)

## Checklist
- [x] I've tested my changes thoroughly and added tests where applicable
- [x] I've updated relevant documentation (if any)
- [x] My code follows the project's conventions
