### PR TITLE
refactor: make Google hosted domain (hd) optional in SSO provider configuration

### DIFF
--- a/app/Helpers.php
+++ b/app/Helpers.php
@@ -109,7 +109,6 @@ function collect_sso_providers(): array
     if (
         config('services.google.client_id')
         && config('services.google.client_secret')
-        && config('services.google.hd')
     ) {
         $providers[] = 'Google';
     }


### PR DESCRIPTION
It removes the required check for the Google hosted domain (`hd`) in the `collect_sso_providers` function. The `SSO_GOOGLE_HOSTED_DOMAIN` configuration is now optional, allowing Google SSO to work without domain restrictions while still supporting them when configured.