### PR TITLE
fix: preserve compilation album artist when editing songs

### DIFF
--- a/app/Services/SongService.php
+++ b/app/Services/SongService.php
@@ -47,7 +47,6 @@ class SongService
             $data->lyrics = $data->lyrics ?: '';
             $data->year = $data->year ?: null;
             $data->genre = $data->genre ?: '';
-            $data->albumArtistName = $data->albumArtistName ?: $data->artistName;
         }
 
         return DB::transaction(function () use ($ids, $data): SongUpdateResult {
@@ -119,7 +118,15 @@ class SongService
         // For nullable fields, use the existing value only if the provided data is explicitly null
         // (i.e., when multiple songs are being updated and the user did not provide a value).
         // This allows us to clear those fields (when the user provides an empty string).
-        $data->albumArtistName ??= $song->album_artist->name;
+        // Album artist handling:
+        // If the user provided an explicit album artist, use it.
+        // If not (null/empty), check if this is a compilation (album artist ≠ song artist).
+        // For compilations, preserve the existing album artist (e.g. "Various Artists").
+        // For non-compilations, let the album artist follow the (potentially updated) song artist.
+        if (!$data->albumArtistName) {
+            $isCompilation = !$song->album_artist->is($song->artist);
+            $data->albumArtistName = $isCompilation ? $song->album_artist->name : $data->artistName;
+        }
         $data->lyrics ??= $song->lyrics;
         $data->track ??= $song->track;
         $data->disc ??= $song->disc;

--- a/app/Values/Song/SongUpdateData.php
+++ b/app/Values/Song/SongUpdateData.php
@@ -16,9 +16,7 @@ final class SongUpdateData implements Arrayable
         public ?string $genre,
         public ?int $year,
         public ?string $lyrics,
-    ) {
-        $this->albumArtistName = $this->albumArtistName ?: $this->artistName;
-    }
+    ) {}
 
     public static function make(
         ?string $title = null,

--- a/tests/Integration/Services/SongServiceTest.php
+++ b/tests/Integration/Services/SongServiceTest.php
@@ -310,4 +310,147 @@ class SongServiceTest extends TestCase
 
         self::assertSame('Amet', $song->title);
     }
+
+    #[Test]
+    public function updateCompilationSongPreservesAlbumArtist(): void
+    {
+        $user = create_user();
+        $this->actingAs($user);
+
+        $variousArtist = Artist::getOrCreate($user, Artist::VARIOUS_NAME);
+        $songArtist = Artist::getOrCreate($user, 'Dark Tranquillity');
+        $album = Album::getOrCreate($variousArtist, 'A Tribute To The Four Horsemen');
+
+        $song = Song::factory()->for($user, 'owner')->createOne([
+            'artist_id' => $songArtist->id,
+            'artist_name' => $songArtist->name,
+            'album_id' => $album->id,
+            'album_name' => $album->name,
+            'track' => 1,
+        ]);
+
+        // Edit the song without providing album artist (as the UI does)
+        $data = SongUpdateData::make(track: 5);
+        $result = $this->service->updateSongs([$song->id], $data);
+
+        /** @var Song $updatedSong */
+        $updatedSong = $result->updatedSongs->first();
+
+        // The album artist should still be "Various Artists", not "Dark Tranquillity"
+        self::assertSame(Artist::VARIOUS_NAME, $updatedSong->album_artist->name);
+        self::assertTrue($updatedSong->album->is($album));
+        self::assertSame(5, $updatedSong->track);
+    }
+
+    #[Test]
+    public function updateCompilationSongArtistPreservesAlbumArtist(): void
+    {
+        $user = create_user();
+        $this->actingAs($user);
+
+        $variousArtist = Artist::getOrCreate($user, Artist::VARIOUS_NAME);
+        $songArtist = Artist::getOrCreate($user, 'Dark Tranquillity');
+        $album = Album::getOrCreate($variousArtist, 'A Tribute To The Four Horsemen');
+
+        $song = Song::factory()->for($user, 'owner')->createOne([
+            'artist_id' => $songArtist->id,
+            'artist_name' => $songArtist->name,
+            'album_id' => $album->id,
+            'album_name' => $album->name,
+        ]);
+
+        // Change the song artist — compilation album artist should be preserved
+        $data = SongUpdateData::make(artistName: 'Sonata Arctica');
+        $result = $this->service->updateSongs([$song->id], $data);
+
+        /** @var Song $updatedSong */
+        $updatedSong = $result->updatedSongs->first();
+
+        self::assertSame('Sonata Arctica', $updatedSong->artist->name);
+        self::assertSame(Artist::VARIOUS_NAME, $updatedSong->album_artist->name);
+        self::assertTrue($updatedSong->album->is($album));
+    }
+
+    #[Test]
+    public function updateMultipleCompilationSongsPreservesAlbumArtist(): void
+    {
+        $user = create_user();
+        $this->actingAs($user);
+
+        $variousArtist = Artist::getOrCreate($user, Artist::VARIOUS_NAME);
+        $album = Album::getOrCreate($variousArtist, 'A Tribute To The Four Horsemen');
+
+        $song1 = Song::factory()->for($user, 'owner')->createOne([
+            'artist_id' => Artist::getOrCreate($user, 'Dark Tranquillity')->id,
+            'artist_name' => 'Dark Tranquillity',
+            'album_id' => $album->id,
+            'album_name' => $album->name,
+        ]);
+
+        $song2 = Song::factory()->for($user, 'owner')->createOne([
+            'artist_id' => Artist::getOrCreate($user, 'Sonata Arctica')->id,
+            'artist_name' => 'Sonata Arctica',
+            'album_id' => $album->id,
+            'album_name' => $album->name,
+        ]);
+
+        // Batch update genre without providing album artist
+        $data = SongUpdateData::make(genre: 'Metal');
+        $result = $this->service->updateSongs([$song1->id, $song2->id], $data);
+
+        foreach ($result->updatedSongs as $updatedSong) {
+            self::assertSame(Artist::VARIOUS_NAME, $updatedSong->album_artist->name);
+            self::assertTrue($updatedSong->album->is($album));
+            self::assertSame('Metal', $updatedSong->genre);
+        }
+    }
+
+    #[Test]
+    public function updateCompilationSongWithExplicitAlbumArtistOverrides(): void
+    {
+        $user = create_user();
+        $this->actingAs($user);
+
+        $variousArtist = Artist::getOrCreate($user, Artist::VARIOUS_NAME);
+        $songArtist = Artist::getOrCreate($user, 'Dark Tranquillity');
+        $album = Album::getOrCreate($variousArtist, 'A Tribute To The Four Horsemen');
+
+        $song = Song::factory()->for($user, 'owner')->createOne([
+            'artist_id' => $songArtist->id,
+            'artist_name' => $songArtist->name,
+            'album_id' => $album->id,
+            'album_name' => $album->name,
+        ]);
+
+        // Explicitly change the album artist — should override
+        $data = SongUpdateData::make(albumArtistName: 'Dark Tranquillity');
+        $result = $this->service->updateSongs([$song->id], $data);
+
+        /** @var Song $updatedSong */
+        $updatedSong = $result->updatedSongs->first();
+
+        self::assertSame('Dark Tranquillity', $updatedSong->album_artist->name);
+        self::assertFalse($updatedSong->album->is($album));
+    }
+
+    #[Test]
+    public function updateNonCompilationSongArtistAlsoUpdatesAlbumArtist(): void
+    {
+        $song = Song::factory()->createOne();
+        $originalAlbumArtist = $song->album_artist;
+
+        // Verify non-compilation: album artist === song artist
+        self::assertTrue($originalAlbumArtist->is($song->artist));
+
+        // Change artist without specifying album artist
+        $data = SongUpdateData::make(artistName: 'New Artist');
+        $result = $this->service->updateSongs([$song->id], $data);
+
+        /** @var Song $updatedSong */
+        $updatedSong = $result->updatedSongs->first();
+
+        // For non-compilation songs, album artist should follow the song artist
+        self::assertSame('New Artist', $updatedSong->artist->name);
+        self::assertSame('New Artist', $updatedSong->album_artist->name);
+    }
 }


### PR DESCRIPTION
## Summary

When editing songs that belong to a compilation album (where album artist ≠ song artist, e.g. "Various Artists"), the album artist was silently replaced with the song's own artist. This ripped the song out of the compilation, creating a duplicate album under the song artist.

**Root cause:** Two places fell back from empty `albumArtistName` to `artistName` without checking if the song was in a compilation:
- `SongUpdateData` constructor: `$this->albumArtistName ?: $this->artistName`
- `SongService::updateSongs()` single-song branch: same pattern

**Fix:**
- Removed the blind fallback from `SongUpdateData` (it's a DTO, shouldn't contain business logic)
- In `SongService::updateSong()`, when no album artist is provided:
  - **Compilation songs** (album artist ≠ song artist): preserve the existing album artist
  - **Non-compilation songs**: let album artist follow the song artist (existing behavior)
  - Explicit album artist value always takes precedence

## Test plan
- [x] 5 new tests covering compilation song edits
- [x] All 836 existing tests pass
- `updateCompilationSongPreservesAlbumArtist` — editing track number doesn't change album artist
- `updateCompilationSongArtistPreservesAlbumArtist` — changing song artist preserves "Various Artists"
- `updateMultipleCompilationSongsPreservesAlbumArtist` — batch editing preserves compilation
- `updateCompilationSongWithExplicitAlbumArtistOverrides` — explicit album artist still works
- `updateNonCompilationSongArtistAlsoUpdatesAlbumArtist` — non-compilation behavior unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed album artist handling during song updates. Compilation songs now preserve their original album artist (e.g., "Various Artists") while non-compilation songs correctly update their album artist when the song artist changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->