### PR TITLE
feat: auto-hide visualizer controls in fullscreen mode

### DIFF
--- a/resources/assets/js/components/screens/VisualizerScreen.vue
+++ b/resources/assets/js/components/screens/VisualizerScreen.vue
@@ -74,6 +74,7 @@ watch(isFullscreen, fullscreen => {
     setupControlHidingTimer()
   } else {
     window.clearTimeout(hideControlsTimeout)
+    showControls.cancel()
     controlsHidden.value = false
   }
 })

--- a/resources/assets/js/components/screens/VisualizerScreen.vue
+++ b/resources/assets/js/components/screens/VisualizerScreen.vue
@@ -56,6 +56,7 @@ const { isFullscreen, toggle: toggleFullscreen } = useFullscreen(container)
 const controlsHidden = ref(false)
 
 const setupControlHidingTimer = () => {
+  window.clearTimeout(hideControlsTimeout)
   hideControlsTimeout = window.setTimeout(() => (controlsHidden.value = true), 5000)
 }
 
@@ -65,7 +66,6 @@ const showControls = throttle(() => {
   }
 
   controlsHidden.value = false
-  window.clearTimeout(hideControlsTimeout)
   setupControlHidingTimer()
 }, 100)
 
@@ -117,6 +117,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   window.clearTimeout(hideControlsTimeout)
+  showControls.cancel()
   freeUp()
 })
 </script>

--- a/resources/assets/js/components/screens/VisualizerScreen.vue
+++ b/resources/assets/js/components/screens/VisualizerScreen.vue
@@ -1,7 +1,13 @@
 <template>
-  <section id="vizContainer" ref="container" :class="{ fullscreen: isFullscreen }" @dblclick.prevent="toggleFullscreen">
+  <section
+    id="vizContainer"
+    ref="container"
+    :class="{ fullscreen: isFullscreen, 'hide-controls': controlsHidden }"
+    @dblclick.prevent="toggleFullscreen"
+    @mousemove="showControls"
+  >
     <div
-      class="absolute z-[1] w-full h-full top-0 left-0 opacity-0 transition-opacity duration-300 ease-in-out hover:opacity-100"
+      class="controls absolute z-[1] w-full h-full top-0 left-0 opacity-0 transition-opacity duration-300 ease-in-out hover:opacity-100"
     >
       <div v-if="selectedVisualizer" class="absolute bottom-8 left-8 px-6 py-4 bg-black/30 rounded-md">
         <h3 class="text-lg mb-2">{{ selectedVisualizer.name }}</h3>
@@ -29,6 +35,7 @@
 import { faUpRightFromSquare } from '@fortawesome/free-solid-svg-icons'
 import { nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useFullscreen } from '@vueuse/core'
+import { throttle } from 'lodash'
 import { logger } from '@/utils/logger'
 import { preferenceStore as preferences } from '@/stores/preferenceStore'
 import { visualizerStore } from '@/stores/visualizerStore'
@@ -37,12 +44,38 @@ import SelectBox from '@/components/ui/form/SelectBox.vue'
 
 const visualizers = visualizerStore.all
 let destroyVisualizer: () => void
+let hideControlsTimeout: number
 
 const el = ref<HTMLElement | null>(null)
 const container = ref<HTMLElement | null>(null)
 const selectedId = ref<Visualizer['id']>()
 
 const { isFullscreen, toggle: toggleFullscreen } = useFullscreen(container)
+
+const controlsHidden = ref(false)
+
+const setupControlHidingTimer = () => {
+  hideControlsTimeout = window.setTimeout(() => (controlsHidden.value = true), 5000)
+}
+
+const showControls = throttle(() => {
+  if (!isFullscreen.value) {
+    return
+  }
+
+  controlsHidden.value = false
+  window.clearTimeout(hideControlsTimeout)
+  setupControlHidingTimer()
+}, 100)
+
+watch(isFullscreen, fullscreen => {
+  if (fullscreen) {
+    setupControlHidingTimer()
+  } else {
+    window.clearTimeout(hideControlsTimeout)
+    controlsHidden.value = false
+  }
+})
 
 const freeUp = () => {
   destroyVisualizer?.()
@@ -81,7 +114,10 @@ onMounted(() => {
   }
 })
 
-onBeforeUnmount(() => freeUp())
+onBeforeUnmount(() => {
+  window.clearTimeout(hideControlsTimeout)
+  freeUp()
+})
 </script>
 
 <style lang="postcss" scoped>
@@ -91,6 +127,15 @@ onBeforeUnmount(() => freeUp())
 
 .fullscreen {
   /* :fullscreen pseudo support is kind of buggy, so we use a class instead */
-  @apply bg-k-bg;
+  @apply bg-k-bg cursor-none;
+}
+
+.fullscreen:not(.hide-controls) {
+  @apply cursor-auto;
+}
+
+.hide-controls .controls {
+  transition: opacity 2s ease-in-out !important;
+  @apply !opacity-0 pointer-events-none;
 }
 </style>

--- a/resources/assets/js/components/screens/VisualizerScreen.vue
+++ b/resources/assets/js/components/screens/VisualizerScreen.vue
@@ -2,12 +2,13 @@
   <section
     id="vizContainer"
     ref="container"
-    :class="{ fullscreen: isFullscreen, 'hide-controls': controlsHidden }"
+    :class="{ fullscreen: isFullscreen, 'cursor-none': isFullscreen && controlsHidden }"
     @dblclick.prevent="toggleFullscreen"
     @mousemove="showControls"
   >
     <div
-      class="controls absolute z-[1] w-full h-full top-0 left-0 opacity-0 transition-opacity duration-300 ease-in-out hover:opacity-100"
+      class="controls absolute z-[1] w-full h-full top-0 left-0 opacity-0 transition-opacity duration-300 ease-in-out"
+      :class="{ 'hover:opacity-100': !isFullscreen, 'show-controls': !controlsHidden && isFullscreen }"
     >
       <div v-if="selectedVisualizer" class="absolute bottom-8 left-8 px-6 py-4 bg-black/30 rounded-md">
         <h3 class="text-lg mb-2">{{ selectedVisualizer.name }}</h3>
@@ -127,15 +128,14 @@ onBeforeUnmount(() => {
 
 .fullscreen {
   /* :fullscreen pseudo support is kind of buggy, so we use a class instead */
-  @apply bg-k-bg cursor-none;
+  @apply bg-k-bg;
 }
 
-.fullscreen:not(.hide-controls) {
-  @apply cursor-auto;
+.controls.show-controls {
+  @apply opacity-100;
 }
 
-.hide-controls .controls {
-  transition: opacity 2s ease-in-out !important;
-  @apply !opacity-0 pointer-events-none;
+.fullscreen .controls:not(.show-controls) {
+  @apply pointer-events-none;
 }
 </style>


### PR DESCRIPTION
## Summary

- Credit info and visualizer dropdown auto-hide after 5 seconds of inactivity in fullscreen mode
- Mouse movement reveals them again (throttled at 100ms)
- Cursor also hides when controls are hidden
- Uses the same pattern as the playback footer's fullscreen auto-hide
- Controls remain always accessible in non-fullscreen mode (unchanged behavior)

## Test plan
- [x] Enter fullscreen (double-click) → controls fade out after 5s
- [x] Move mouse → controls reappear, timer resets
- [x] Exit fullscreen → controls return to normal hover behavior
- [x] Timer cleaned up on component unmount

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved fullscreen viewing: UI controls auto-show on mouse movement and auto-hide after 5 seconds of inactivity for uninterrupted playback.
  * Cursor is hidden in fullscreen when controls are hidden for a cleaner view; controls remain fully visible when hovering outside fullscreen.
* **Bug Fixes**
  * More reliable show/hide behavior when entering/exiting fullscreen and improved cleanup to prevent stray controls or lingering timers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->